### PR TITLE
Add return annotation to `get_jobs` function

### DIFF
--- a/sarc/jobs/job.py
+++ b/sarc/jobs/job.py
@@ -154,7 +154,7 @@ def get_jobs(
     start: Union[str, datetime] = None,
     end: Union[str, datetime] = None,
     query_options: dict = {},
-):
+) -> list[SlurmJob]:
     """Get jobs that match the query.
 
     Arguments:


### PR DESCRIPTION
I had a glimpse of the `job` being typed as `Any` in your demo this morning @bouthilx . This is just a nitpicky typing improvement. Not sure if this is actually correct or useful.
- Does this always return a `list[SlurmJob]`?
- Is the type checker already able to infer that `coll.find_by(query, **query_options)` returns a `list[SlurmJob]`?