### PR TITLE
Handle gpu types in Resources and priority=None

### DIFF
--- a/sarc/jobs/job.py
+++ b/sarc/jobs/job.py
@@ -50,6 +50,7 @@ class SlurmResources(BaseModel):
     node: Optional[int]
     billing: Optional[int]
     gres_gpu: Optional[int]
+    gpu_type: Optional[str]
 
 
 class SlurmJob(BaseModel):
@@ -80,7 +81,7 @@ class SlurmJob(BaseModel):
 
     # Miscellaneous
     constraints: Optional[str]
-    priority: int
+    priority: Optional[int]
     qos: Optional[str]
 
     # Flags

--- a/sarc/jobs/sacct.py
+++ b/sarc/jobs/sacct.py
@@ -121,7 +121,14 @@ class SAcctScraper:
                     continue
                 if aname := alloc["name"]:
                     key += f"_{aname}"
-                vals[key] = alloc["count"]
+
+                if key.startswith("gres_gpu:"):
+                    value = key.split(":")[1]
+                    key = "gpu_type"
+                else:
+                    value = alloc["count"]
+
+                vals[key] = value
 
         nodes = entry["nodes"]
 


### PR DESCRIPTION
Sinon ça plante pour des tâches qui contiennent des spécifications du type de GPU. Ex:
```
          'requested': [{'count': 4, 'id': 1, 'name': None, 'type': 'cpu'},
                        {'count': 16384, 'id': 2, 'name': None, 'type': 'mem'},
                        {'count': 1, 'id': 4, 'name': None, 'type': 'node'},
                        {'count': 1, 'id': 5, 'name': None, 'type': 'billing'},
                        {'count': 1, 'id': 1001, 'name': 'gpu', 'type': 'gres'},
                        {'count': 1,
                         'id': 1002,
                         'name': 'gpu:p100',
                         'type': 'gres'}]},

```