### PR TITLE
SARC needs zoneinfo which is new in python 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 packages = [{include = 'sarc'}]
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.9"
 fabric = "^3.0.0"
 prometheus-api-client = "^0.5.2"
 pydantic = "^1.10.4"


### PR DESCRIPTION
I also note that the CI doesn't test with python 3.8 which would have caught this.