### PR TITLE
Set container of choices to CLI

### DIFF
--- a/sarc/cli/acquire/jobs.py
+++ b/sarc/cli/acquire/jobs.py
@@ -4,6 +4,7 @@ from datetime import datetime
 
 from simple_parsing import field
 
+from sarc.cli.utils import clusters
 from sarc.config import config
 from sarc.jobs.sacct import sacct_mongodb_import
 
@@ -11,7 +12,7 @@ from sarc.jobs.sacct import sacct_mongodb_import
 @dataclass
 class AcquireJobs:
     cluster_names: list[str] = field(
-        alias=["-c"], default_factory=list, choices=list(config().clusters.keys())
+        alias=["-c"], default_factory=list, choices=clusters
     )
 
     dates: list[str] = field(alias=["-d"], default_factory=list)

--- a/sarc/cli/utils.py
+++ b/sarc/cli/utils.py
@@ -1,0 +1,15 @@
+from sarc.config import config
+
+
+class ChoicesContainer:
+    def __init__(self, choices):
+        self.choices = choices
+
+    def __contains__(self, item):
+        return item in self.choices
+
+    def __iter__(self):
+        return iter(self.choices)
+
+
+clusters = ChoicesContainer(list(config().clusters.keys()))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,3 +67,14 @@ def test_config(
     )
     with using_config(conf):
         yield conf
+
+
+@pytest.fixture
+def cli_main():
+    from sarc.cli import main
+    from sarc.cli.utils import clusters
+
+    # Update possible choices based on the current test config
+    clusters.choices = list(config().clusters.keys())
+
+    yield main


### PR DESCRIPTION
The choices are based on `config()` at import time, but the config() maybe changed in between (especially during tests). Setting the choices with a container instead allows us to change the options later on.