### PR TITLE
Fix tzlocal

### DIFF
--- a/sarc/config.py
+++ b/sarc/config.py
@@ -8,6 +8,7 @@ from functools import cached_property
 from pathlib import Path
 from typing import Any, Union
 
+import tzlocal
 from bson import ObjectId
 from pydantic import BaseModel as _BaseModel
 from pydantic import Extra, validator
@@ -15,7 +16,7 @@ from pydantic import Extra, validator
 MTL = zoneinfo.ZoneInfo("America/Montreal")
 PST = zoneinfo.ZoneInfo("America/Vancouver")
 UTC = zoneinfo.ZoneInfo("UTC")
-TZLOCAL = zoneinfo.ZoneInfo(str(datetime.now().astimezone().tzinfo))
+TZLOCAL = zoneinfo.ZoneInfo(tzlocal.get_localzone_name())
 
 
 class ConfigurationError(Exception):


### PR DESCRIPTION
Now that we are in daylight saving time instead of eastern standard time, the code to determine local time zone is failing because `zoneinfo` does not know what EDT is. Using
`tzlocal.get_localzone_name()` works well enough because `datetime` seems to know we are in daylight saving time.