### PR TITLE
Add simple install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,15 +3,44 @@
 
 In-house tool to monitor the usage of various computational resources at Mila.
 
-## Scripts meant to be run on their own
+## Installation and setup
 
-```
-sarc/account_matching/make_matches.py
-sarc/account_matching/update_account_matches_in_database.py
-sarc/inode_storage_scanner/get_diskusage.py  (stub)
+This is the guide to use the client. For deployment, see `docs/deployment.md`.
+
+To install sarc, git clone the repo and install `sarc` using `poetry`.
+
+```bash
+$ git clone git@github.com:mila-iqia/SARC.git
+$ cd SARC
+$ poetry install
 ```
 
-## Before commits
+`sarc` will be looking into the current working directory to find the dev config file. To work with prod config or 
+from any directory set the environment variable as follow.
+
+```bash
+$ export SARC_CONFIG=/path/to/SARC/config/sarc-prod.json
+```
+
+To access the database, you need to setup the mila idt vpn and create an ssh
+tunnel. If you never accessed the VM, see documention here first https://mila-iqia.atlassian.net/wiki/spaces/IDT/pages/2216329289/VM+SARC.
+
+To create the ssh tunnel:
+
+
+```bash
+$ ssh -L 27017:localhost:27017 sarc
+```
+
+You can now test on your machine a simple example to see if `sarc` is able to access the database:
+
+```bash 
+$ poetry run python example/waste_stats.py
+```
+
+## Contributing
+
+### Before commits
 
 Those commands are for the proper formatting.
 ```
@@ -22,12 +51,12 @@ tox -e black
 tox -e lint
 ```
 
-## How to add dependencies
+### How to add dependencies
 
 TODO : How does poetry work? Needs a simple example here for the command to add a python module like `ldap3`. What are we supposed to type?
 
 
-## How to run the tests suite
+### How to run the tests suite
 
 This runs the tests.
 ```
@@ -39,5 +68,13 @@ Later you can start the virtual machine with
 ```
 podman machine init
 podman machine start
+```
+
+### Scripts meant to be run on their own
+
+```
+sarc/account_matching/make_matches.py
+sarc/account_matching/update_account_matches_in_database.py
+sarc/inode_storage_scanner/get_diskusage.py  (stub)
 ```
 


### PR DESCRIPTION
J'aurais pu mettre ça dans le tutoriel pour identifier les chercheurs qui gaspillage les ressources mais je me suis dit que ça servirait plus dans le readme que dans un tuto spécifique.