### PR TITLE
fix temporary files detection 

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import tempfile
 import zoneinfo
 from pathlib import Path
 from unittest.mock import MagicMock, mock_open, patch
@@ -181,7 +182,7 @@ def mock_file(file_contents):
 
         if filename in file_contents:
             return mock_open(read_data=file_contents[filename]).return_value
-        if filename.startswith("/tmp"):
+        if filename.startswith(tempfile.gettempdir()):
             return original(filename, *vargs, **kwargs)
         else:
             # we haven't found a way to pass through the other calls


### PR DESCRIPTION
fix temporary files detection by testing filename against `tempfile.gettempdir()` instead of hardcoded `/tmp/`