### PR TITLE
Fix prometheus scraping

### DIFF
--- a/sarc/cli/acquire/jobs.py
+++ b/sarc/cli/acquire/jobs.py
@@ -82,10 +82,10 @@ class AcquireJobs:
 
     dates: list[str] = field(alias=["-d"], default_factory=list)
 
-    ignore_statistics: bool = field(
+    no_prometheus: bool = field(
         alias=["-s"],
         action="store_true",
-        help="Ignore statistics, avoiding connection to prometheus (default: False)",
+        help="Avoid any scraping requiring connection to prometheus (default: False)",
     )
 
     def execute(self) -> int:
@@ -100,7 +100,7 @@ class AcquireJobs:
                     )
 
                     sacct_mongodb_import(
-                        clusters_configs[cluster_name], date, self.ignore_statistics
+                        clusters_configs[cluster_name], date, self.no_prometheus
                     )
                     if is_auto:
                         _dates_set_last_date(cluster_name, date)

--- a/sarc/jobs/job.py
+++ b/sarc/jobs/job.py
@@ -151,7 +151,7 @@ class SlurmJob(BaseModel):
 
         if self.stored_statistics and not recompute:
             return self.stored_statistics
-        elif self.end_time:
+        elif self.end_time and self.fetch_cluster_config().prometheus_url:
             statistics = compute_job_statistics(self)
             if save:
                 self.stored_statistics = statistics

--- a/sarc/jobs/series.py
+++ b/sarc/jobs/series.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
 from datetime import datetime
+from typing import TYPE_CHECKING
 
 from pandas import DataFrame
 from prometheus_api_client import MetricRangeDataFrame
 
 from sarc.config import MTL, UTC
 from sarc.jobs.job import JobStatistics, Statistics
-from sarc.jobs.sacct import SlurmJob
+
+if TYPE_CHECKING:
+    from sarc.jobs.sacct import SlurmJob
 
 
 # pylint: disable=too-many-branches
@@ -47,8 +50,7 @@ def get_job_time_series(
     if metric not in slurm_job_metric_names:
         raise ValueError(f"Unknown metric name: {metric}")
 
-    nodes = "|".join(job.nodes)
-    selector = f'{metric}{{slurmjobid=~"{job.job_id}",instance=~"{nodes}"}}'
+    selector = f'{metric}{{slurmjobid=~"{job.job_id}"}}'
 
     now = datetime.now(tz=UTC).astimezone(MTL)
 

--- a/tests/functional/jobs/test_func_get_job_time_series/test_get_job_time_series_end_time_in_future_.txt
+++ b/tests/functional/jobs/test_func_get_job_time_series/test_get_job_time_series_end_time_in_future_.txt
@@ -1,1 +1,1 @@
-slurm_job_core_usage{slurmjobid=~"1",instance=~"cn-c021"}[10800s:108s] 
+slurm_job_core_usage{slurmjobid=~"1"}[10800s:108s] 

--- a/tests/functional/jobs/test_func_get_job_time_series/test_get_job_time_series_end_time_in_past_.txt
+++ b/tests/functional/jobs/test_func_get_job_time_series/test_get_job_time_series_end_time_in_past_.txt
@@ -1,1 +1,1 @@
-slurm_job_core_usage{slurmjobid=~"1",instance=~"cn-c021"}[7200s:72s]  offset 3600s
+slurm_job_core_usage{slurmjobid=~"1"}[7200s:72s]  offset 3600s

--- a/tests/functional/jobs/test_func_get_job_time_series/test_get_job_time_series_job_id_.txt
+++ b/tests/functional/jobs/test_func_get_job_time_series/test_get_job_time_series_job_id_.txt
@@ -1,1 +1,1 @@
-slurm_job_core_usage{slurmjobid=~"10",instance=~"cn-c021"}[10800s:108s] 
+slurm_job_core_usage{slurmjobid=~"10"}[10800s:108s] 

--- a/tests/functional/jobs/test_func_get_job_time_series/test_get_job_time_series_no_end_time_.txt
+++ b/tests/functional/jobs/test_func_get_job_time_series/test_get_job_time_series_no_end_time_.txt
@@ -1,1 +1,1 @@
-slurm_job_core_usage{slurmjobid=~"1",instance=~"cn-c021"}[10800s:108s] 
+slurm_job_core_usage{slurmjobid=~"1"}[10800s:108s] 

--- a/tests/functional/jobs/test_func_get_job_time_series/test_intervals_0_1_.txt
+++ b/tests/functional/jobs/test_func_get_job_time_series/test_intervals_0_1_.txt
@@ -1,1 +1,1 @@
-avg_over_time(slurm_job_fp16_gpu{slurmjobid=~"1",instance=~"cn-c021"}[10800s] )[10800s:10800s]
+avg_over_time(slurm_job_fp16_gpu{slurmjobid=~"1"}[10800s] )[10800s:10800s]

--- a/tests/functional/jobs/test_func_get_job_time_series/test_intervals_1080_0_20_.txt
+++ b/tests/functional/jobs/test_func_get_job_time_series/test_intervals_1080_0_20_.txt
@@ -1,1 +1,1 @@
-avg_over_time(slurm_job_fp16_gpu{slurmjobid=~"1",instance=~"cn-c021"}[1080s] )[10800s:1080s]
+avg_over_time(slurm_job_fp16_gpu{slurmjobid=~"1"}[1080s] )[10800s:1080s]

--- a/tests/functional/jobs/test_func_get_job_time_series/test_intervals_10_20_.txt
+++ b/tests/functional/jobs/test_func_get_job_time_series/test_intervals_10_20_.txt
@@ -1,1 +1,1 @@
-avg_over_time(slurm_job_fp16_gpu{slurmjobid=~"1",instance=~"cn-c021"}[540s] )[10800s:540s]
+avg_over_time(slurm_job_fp16_gpu{slurmjobid=~"1"}[540s] )[10800s:540s]

--- a/tests/functional/jobs/test_func_get_job_time_series/test_measure_and_aggregation_None_interval_.txt
+++ b/tests/functional/jobs/test_func_get_job_time_series/test_measure_and_aggregation_None_interval_.txt
@@ -1,1 +1,1 @@
-slurm_job_fp16_gpu{slurmjobid=~"1",instance=~"cn-c021"}[10800s:108s] 
+slurm_job_fp16_gpu{slurmjobid=~"1"}[10800s:108s] 

--- a/tests/functional/jobs/test_func_get_job_time_series/test_measure_and_aggregation_None_total_.txt
+++ b/tests/functional/jobs/test_func_get_job_time_series/test_measure_and_aggregation_None_total_.txt
@@ -1,1 +1,1 @@
-slurm_job_fp16_gpu{slurmjobid=~"1",instance=~"cn-c021"}[10800s:108s] 
+slurm_job_fp16_gpu{slurmjobid=~"1"}[10800s:108s] 

--- a/tests/functional/jobs/test_func_get_job_time_series/test_measure_and_aggregation_avg_over_time_interval_.txt
+++ b/tests/functional/jobs/test_func_get_job_time_series/test_measure_and_aggregation_avg_over_time_interval_.txt
@@ -1,1 +1,1 @@
-avg_over_time(slurm_job_fp16_gpu{slurmjobid=~"1",instance=~"cn-c021"}[108s] )[10800s:108s]
+avg_over_time(slurm_job_fp16_gpu{slurmjobid=~"1"}[108s] )[10800s:108s]

--- a/tests/functional/jobs/test_func_get_job_time_series/test_measure_and_aggregation_avg_over_time_total_.txt
+++ b/tests/functional/jobs/test_func_get_job_time_series/test_measure_and_aggregation_avg_over_time_total_.txt
@@ -1,1 +1,1 @@
-avg_over_time(slurm_job_fp16_gpu{slurmjobid=~"1",instance=~"cn-c021"}[10800s] )[10800s:10800s]
+avg_over_time(slurm_job_fp16_gpu{slurmjobid=~"1"}[10800s] )[10800s:10800s]

--- a/tests/functional/jobs/test_func_get_job_time_series/test_measure_and_aggregation_quantile_over_time_interval_.txt
+++ b/tests/functional/jobs/test_func_get_job_time_series/test_measure_and_aggregation_quantile_over_time_interval_.txt
@@ -1,1 +1,1 @@
-quantile_over_time(slurm_job_fp16_gpu{slurmjobid=~"1",instance=~"cn-c021"}[108s] )[10800s:108s]
+quantile_over_time(slurm_job_fp16_gpu{slurmjobid=~"1"}[108s] )[10800s:108s]

--- a/tests/functional/jobs/test_func_get_job_time_series/test_measure_and_aggregation_quantile_over_time_total_.txt
+++ b/tests/functional/jobs/test_func_get_job_time_series/test_measure_and_aggregation_quantile_over_time_total_.txt
@@ -1,1 +1,1 @@
-quantile_over_time(slurm_job_fp16_gpu{slurmjobid=~"1",instance=~"cn-c021"}[10800s] )[10800s:10800s]
+quantile_over_time(slurm_job_fp16_gpu{slurmjobid=~"1"}[10800s] )[10800s:10800s]

--- a/tests/functional/jobs/test_func_sacct/test_get_gpu_type_from_prometheus_json_jobs0_test_config0_.txt
+++ b/tests/functional/jobs/test_func_sacct/test_get_gpu_type_from_prometheus_json_jobs0_test_config0_.txt
@@ -44,5 +44,11 @@ Found 1 job(s):
         "gres_gpu": 1,
         "gpu_type": "phantom_gpu"
     },
-    "stored_statistics": null
+    "stored_statistics": {
+        "gpu_utilization": null,
+        "gpu_memory": null,
+        "gpu_power": null,
+        "cpu_utilization": null,
+        "system_memory": null
+    }
 }


### PR DESCRIPTION
The query using node names was not working on DRAC cluster, and the query for inference the GPU types was only fetching the past X minutes, effectively missing any data for the majority of jobs.