### PR TITLE
Add --allusers to sacct

### DIFF
--- a/config/sarc-prod.json
+++ b/config/sarc-prod.json
@@ -62,8 +62,8 @@
             "duc_inodes_command": null,
             "duc_storage_command": null,
             "diskusage_report_command": "diskusage_report --project --all_users",
-            "prometheus_url": "https://mila-thanos.calculquebec.ca",
-            "prometheus_headers_file": "secrets/drac_prometheus/headers.json",
+            "prometheus_url": null,
+            "prometheus_headers_file": null,
             "start_date": "2022-04-01",
             "nodes_info_file": "secrets/nodes_graham.txt"
         },
@@ -75,8 +75,8 @@
             "duc_inodes_command": null,
             "duc_storage_command": null,
             "diskusage_report_command": "diskusage_report --project --all_users",
-            "prometheus_url": "https://mila-thanos.calculquebec.ca",
-            "prometheus_headers_file": "secrets/drac_prometheus/headers.json",
+            "prometheus_url": null,
+            "prometheus_headers_file": null,
             "start_date": "2022-04-01",
             "nodes_info_file": "secrets/nodes_cedar.txt"
         }

--- a/sarc/jobs/sacct.py
+++ b/sarc/jobs/sacct.py
@@ -287,10 +287,10 @@ def update_allocated_gpu_type(cluster: ClusterConfig, entry: SlurmJob) -> Option
             entry.allocated.gpu_type = output[0]["metric"]["gpu_type"]
     else:
         # No prometheus config. Try to get GPU type from local JSON file.
-        gpu_types = [cluster.node_to_gpu[nodename] for nodename in entry.nodes]
+        gpu_types = {cluster.node_to_gpu[nodename] for nodename in entry.nodes}
         # We should not have more than 1 GPU type per job.
         assert len(gpu_types) <= 1
         if gpu_types:
-            entry.allocated.gpu_type = gpu_types[0]
+            entry.allocated.gpu_type = gpu_types.pop()
 
     return entry.allocated.gpu_type

--- a/sarc/jobs/sacct.py
+++ b/sarc/jobs/sacct.py
@@ -97,9 +97,10 @@ class SAcctScraper:
 
     def __iter__(self) -> Iterator[SlurmJob]:
         """Fetch and iterate on all jobs as SlurmJob objects."""
+        version = self.get_raw().get("meta", {}).get("Slurm", {}).get("version", None)
         for entry in self.get_raw()["jobs"]:
             try:
-                converted = self.convert(entry)
+                converted = self.convert(entry, version)
                 if converted is not None:
                     yield converted
             except Exception:  # pylint: disable=broad-exception-caught
@@ -109,7 +110,7 @@ class SAcctScraper:
                 print(pformat(entry), file=sys.stderr)
                 print("====================================", file=sys.stderr)
 
-    def convert(self, entry: dict) -> Optional[SlurmJob]:
+    def convert(self, entry: dict, version: dict = None) -> Optional[SlurmJob]:
         """Convert a single job entry from sacct to a SlurmJob."""
         resources = {"requested": {}, "allocated": {}}
         tracked_resources = ["cpu", "mem", "gres", "node", "billing"]
@@ -137,7 +138,13 @@ class SAcctScraper:
 
         nodes = entry["nodes"]
 
-        flags = {k: True for k in entry["flags"]}
+        tracked_flags = [
+            "CLEAR_SCHEDULING",
+            "STARTED_ON_SUBMIT",
+            "STARTED_ON_SCHEDULE",
+            "STARTED_ON_BACKFILL",
+        ]
+        flags = {k: True for k in entry["flags"] if k in tracked_flags}
 
         submit_time = parse_in_timezone(entry["time"]["submission"])
         start_time = parse_in_timezone(entry["time"]["start"])
@@ -158,35 +165,66 @@ class SAcctScraper:
                 entry["cluster"],
                 self.cluster.name,
             )
+        if version is None or version["major"] < 23:
+            return SlurmJob(
+                cluster_name=self.cluster.name,
+                job_id=entry["job_id"],
+                array_job_id=entry["array"]["job_id"] or None,
+                task_id=entry["array"]["task_id"],
+                name=entry["name"],
+                user=entry["user"],
+                group=entry["group"],
+                account=entry["account"],
+                job_state=entry["state"]["current"],
+                exit_code=entry["exit_code"]["return_code"],
+                signal=entry["exit_code"].get("signal", {}).get("signal_id", None),
+                time_limit=(tlimit := entry["time"]["limit"]) and tlimit * 60,
+                submit_time=submit_time,
+                start_time=start_time,
+                end_time=end_time,
+                elapsed_time=elapsed_time,
+                partition=entry["partition"],
+                nodes=sorted(expand_hostlist(nodes))
+                if nodes != "None assigned"
+                else [],
+                constraints=entry["constraints"],
+                priority=entry["priority"],
+                qos=entry["qos"],
+                work_dir=entry["working_directory"],
+                **resources,
+                **flags,
+            )
+        if version["major"] == 23:
+            return SlurmJob(
+                cluster_name=self.cluster.name,
+                job_id=entry["job_id"],
+                array_job_id=entry["array"]["job_id"] or None,
+                task_id=entry["array"]["task_id"]["number"],
+                name=entry["name"],
+                user=entry["user"],
+                group=entry["group"],
+                account=entry["account"],
+                job_state=entry["state"]["current"],
+                exit_code=entry["exit_code"]["return_code"],
+                signal=entry["exit_code"].get("signal", {}).get("signal_id", None),
+                time_limit=(tlimit := entry["time"]["limit"]["number"]) and tlimit * 60,
+                submit_time=submit_time,
+                start_time=start_time,
+                end_time=end_time,
+                elapsed_time=elapsed_time,
+                partition=entry["partition"],
+                nodes=sorted(expand_hostlist(nodes))
+                if nodes != "None assigned"
+                else [],
+                constraints=entry["constraints"],
+                priority=entry["priority"]["number"],
+                qos=entry["qos"],
+                work_dir=entry["working_directory"],
+                **resources,
+                **flags,
+            )
 
-        job = SlurmJob(
-            cluster_name=self.cluster.name,
-            job_id=entry["job_id"],
-            array_job_id=entry["array"]["job_id"] or None,
-            task_id=entry["array"]["task_id"],
-            name=entry["name"],
-            user=entry["user"],
-            group=entry["group"],
-            account=entry["account"],
-            job_state=entry["state"]["current"],
-            exit_code=entry["exit_code"]["return_code"],
-            signal=entry["exit_code"].get("signal", {}).get("signal_id", None),
-            time_limit=(tlimit := entry["time"]["limit"]) and tlimit * 60,
-            submit_time=submit_time,
-            start_time=start_time,
-            end_time=end_time,
-            elapsed_time=elapsed_time,
-            partition=entry["partition"],
-            nodes=sorted(expand_hostlist(nodes)) if nodes != "None assigned" else [],
-            constraints=entry["constraints"],
-            priority=entry["priority"],
-            qos=entry["qos"],
-            work_dir=entry["working_directory"],
-            **resources,
-            **flags,
-        )
-
-        return job
+        raise ValueError(f"Unsupported slurm version: {version}")
 
 
 def sacct_mongodb_import(

--- a/sarc/jobs/sacct.py
+++ b/sarc/jobs/sacct.py
@@ -62,7 +62,7 @@ class SAcctScraper:
         end = self.end.strftime(fmt)
         accounts = self.cluster.accounts and ",".join(self.cluster.accounts)
         accounts_option = f"-A {accounts}" if accounts else ""
-        cmd = f"{self.cluster.sacct_bin} {accounts_option} -X -S '{start}' -E '{end}' --json"
+        cmd = f"{self.cluster.sacct_bin} {accounts_option} -X -S '{start}' -E '{end}' --allusers --json"
         print(f"{self.cluster.name} $ {cmd}")
         results = self.cluster.ssh.run(cmd, hide=True)
         return json.loads(results.stdout[results.stdout.find("{") :])

--- a/tests/functional/jobs/sacct_outputs/slurm_21_8_8.json
+++ b/tests/functional/jobs/sacct_outputs/slurm_21_8_8.json
@@ -1,0 +1,181 @@
+{
+    "meta": {
+        "plugin": {
+            "type": "openapi/dbv0.0.37",
+            "name": "Slurm OpenAPI DB v0.0.37"
+        },
+        "Slurm": {
+            "version": {
+                "major": 21,
+                "micro": 8,
+                "minor": 8
+            },
+            "release": "21.08.8-2"
+        }
+    },
+    "errors": [],
+    "jobs": [
+        {
+            "account": "rrg-bengioy-ad_gpu",
+            "comment": {
+                "administrator": null,
+                "job": null,
+                "system": null
+            },
+            "allocation_nodes": 1,
+            "array": {
+                "job_id": 0,
+                "limits": {
+                    "max": {
+                        "running": {
+                            "tasks": 0
+                        }
+                    }
+                },
+                "task": null,
+                "task_id": null
+            },
+            "association": {
+                "account": "rrg-bengioy-ad_gpu",
+                "cluster": "cedar",
+                "partition": null,
+                "user": "purah"
+            },
+            "cluster": "cedar",
+            "constraints": "[p100|p100l|v100l]",
+            "derived_exit_code": {
+                "status": "SUCCESS",
+                "return_code": 0
+            },
+            "time": {
+                "elapsed": 86301,
+                "eligible": 1673275023,
+                "end": 1673369386,
+                "start": 1673275023,
+                "submission": 1673275023,
+                "suspended": 0,
+                "system": {
+                    "seconds": 0,
+                    "microseconds": 0
+                },
+                "limit": 1440,
+                "total": {
+                    "seconds": 0,
+                    "microseconds": 0
+                },
+                "user": {
+                    "seconds": 0,
+                    "microseconds": 0
+                }
+            },
+            "exit_code": {
+                "status": "SUCCESS",
+                "return_code": 0
+            },
+            "flags": [
+                "CLEAR_SCHEDULING",
+                "STARTED_ON_BACKFILL"
+            ],
+            "group": "purah",
+            "het": {
+                "job_id": 0,
+                "job_offset": null
+            },
+            "job_id": 55978384,
+            "name": "submitit",
+            "mcs": {
+                "label": ""
+            },
+            "nodes": "cdr896",
+            "partition": "gpubackfill",
+            "priority": 1314155,
+            "qos": "normal",
+            "required": {
+                "CPUs": 4,
+                "memory": 40960
+            },
+            "kill_request_user": null,
+            "reservation": {
+                "id": 0,
+                "name": 0
+            },
+            "state": {
+                "current": "REQUEUED",
+                "reason": "None"
+            },
+            "steps": [],
+            "tres": {
+                "allocated": [
+                    {
+                        "type": "cpu",
+                        "name": null,
+                        "id": 1,
+                        "count": 4
+                    },
+                    {
+                        "type": "mem",
+                        "name": null,
+                        "id": 2,
+                        "count": 40960
+                    },
+                    {
+                        "type": "node",
+                        "name": null,
+                        "id": 4,
+                        "count": 1
+                    },
+                    {
+                        "type": "billing",
+                        "name": null,
+                        "id": 5,
+                        "count": 1
+                    },
+                    {
+                        "type": "gres",
+                        "name": "gpu",
+                        "id": 1001,
+                        "count": 1
+                    }
+                ],
+                "requested": [
+                    {
+                        "type": "cpu",
+                        "name": null,
+                        "id": 1,
+                        "count": 4
+                    },
+                    {
+                        "type": "mem",
+                        "name": null,
+                        "id": 2,
+                        "count": 40960
+                    },
+                    {
+                        "type": "node",
+                        "name": null,
+                        "id": 4,
+                        "count": 1
+                    },
+                    {
+                        "type": "billing",
+                        "name": null,
+                        "id": 5,
+                        "count": 1
+                    },
+                    {
+                        "type": "gres",
+                        "name": "gpu",
+                        "id": 1001,
+                        "count": 1
+                    }
+                ]
+            },
+            "user": "purah",
+            "wckey": {
+                "wckey": "submitit",
+                "flags": []
+            },
+            "working_directory": "/scratch/purah/meta_internship"
+        }
+    ]
+}

--- a/tests/functional/jobs/sacct_outputs/slurm_22_5_9.json
+++ b/tests/functional/jobs/sacct_outputs/slurm_22_5_9.json
@@ -1,0 +1,182 @@
+{
+    "meta": {
+        "plugin": {
+            "type": "openapi/dbv0.0.38",
+            "name": "Slurm OpenAPI DB v0.0.38"
+        },
+        "Slurm": {
+            "version": {
+                "major": 22,
+                "micro": 9,
+                "minor": 5
+            },
+            "release": "22.05.9"
+        }
+    },
+    "errors": [],
+    "jobs": [
+        {
+            "account": "rrg-bengioy-ad_gpu",
+            "comment": {
+                "administrator": null,
+                "job": null,
+                "system": null
+            },
+            "allocation_nodes": 4,
+            "array": {
+                "job_id": 20247445,
+                "limits": {
+                    "max": {
+                        "running": {
+                            "tasks": 0
+                        }
+                    }
+                },
+                "task": null,
+                "task_id": 100
+            },
+            "association": {
+                "account": "rrg-bengioy-ad_gpu",
+                "cluster": "narval",
+                "partition": null,
+                "user": "hudson"
+            },
+            "cluster": "narval",
+            "constraints": "[a100]",
+            "container": null,
+            "derived_exit_code": {
+                "status": "SUCCESS",
+                "return_code": 0
+            },
+            "time": {
+                "elapsed": 124403,
+                "eligible": 1692160814,
+                "end": 1693865044,
+                "start": 1693740641,
+                "submission": 1692160813,
+                "suspended": 0,
+                "system": {
+                    "seconds": 0,
+                    "microseconds": 0
+                },
+                "limit": 2880,
+                "total": {
+                    "seconds": 0,
+                    "microseconds": 0
+                },
+                "user": {
+                    "seconds": 0,
+                    "microseconds": 0
+                }
+            },
+            "exit_code": {
+                "status": "SUCCESS",
+                "return_code": 0
+            },
+            "flags": [
+                "CLEAR_SCHEDULING",
+                "STARTED_ON_SCHEDULE"
+            ],
+            "group": "hudson",
+            "het": {
+                "job_id": 0,
+                "job_offset": null
+            },
+            "job_id": 20247445,
+            "name": "roberta-encoder-with_scheduler",
+            "mcs": {
+                "label": ""
+            },
+            "nodes": "ng[30103,30203,30706-30707]",
+            "partition": "gpubase_bynode_b4",
+            "priority": 1550993,
+            "qos": "normal",
+            "required": {
+                "CPUs": 96,
+                "memory": 65536
+            },
+            "kill_request_user": null,
+            "reservation": {
+                "id": 0,
+                "name": 0
+            },
+            "state": {
+                "current": "FAILED",
+                "reason": "None"
+            },
+            "steps": [],
+            "tres": {
+                "allocated": [
+                    {
+                        "type": "cpu",
+                        "name": null,
+                        "id": 1,
+                        "count": 96
+                    },
+                    {
+                        "type": "mem",
+                        "name": null,
+                        "id": 2,
+                        "count": 262144
+                    },
+                    {
+                        "type": "node",
+                        "name": null,
+                        "id": 4,
+                        "count": 4
+                    },
+                    {
+                        "type": "billing",
+                        "name": null,
+                        "id": 5,
+                        "count": 16
+                    },
+                    {
+                        "type": "gres",
+                        "name": "gpu",
+                        "id": 1001,
+                        "count": 16
+                    }
+                ],
+                "requested": [
+                    {
+                        "type": "cpu",
+                        "name": null,
+                        "id": 1,
+                        "count": 96
+                    },
+                    {
+                        "type": "mem",
+                        "name": null,
+                        "id": 2,
+                        "count": 262144
+                    },
+                    {
+                        "type": "node",
+                        "name": null,
+                        "id": 4,
+                        "count": 4
+                    },
+                    {
+                        "type": "billing",
+                        "name": null,
+                        "id": 5,
+                        "count": 16
+                    },
+                    {
+                        "type": "gres",
+                        "name": "gpu",
+                        "id": 1001,
+                        "count": 16
+                    }
+                ]
+            },
+            "user": "hudson",
+            "wckey": {
+                "wckey": "",
+                "flags": []
+            },
+            "working_directory": "/lustre07/scratch/hudson/LLL"
+        }
+    ]
+}

--- a/tests/functional/jobs/sacct_outputs/slurm_23_2_6.json
+++ b/tests/functional/jobs/sacct_outputs/slurm_23_2_6.json
@@ -96,7 +96,7 @@
             "flags": [
                 "STARTED_ON_SUBMIT"
             ],
-            "group": null,
+            "group": "masterkohga",
             "het": {
                 "job_id": 0,
                 "job_offset": {

--- a/tests/functional/jobs/sacct_outputs/slurm_23_2_6.json
+++ b/tests/functional/jobs/sacct_outputs/slurm_23_2_6.json
@@ -1,0 +1,232 @@
+{
+    "meta": {
+        "plugins": {
+            "data_parser": "data_parser/v0.0.39",
+            "accounting_storage": "accounting_storage/slurmdbd"
+        },
+        "command": [
+            "/opt/slurm/bin/sacct",
+            "-X",
+            "-S",
+            "2023-10-05T00:00",
+            "-E",
+            "2023-10-06T00:00",
+            "--allusers",
+            "--json"
+        ],
+        "Slurm": {
+            "version": {
+                "major": 23,
+                "micro": 6,
+                "minor": 2
+            },
+            "release": "23.02.6"
+        }
+    },
+    "jobs": [
+        {
+            "account": "mila",
+            "comment": {
+                "administrator": "",
+                "job": "",
+                "system": ""
+            },
+            "allocation_nodes": 1,
+            "array": {
+                "job_id": 0,
+                "limits": {
+                    "max": {
+                        "running": {
+                            "tasks": 0
+                        }
+                    }
+                },
+                "task_id": {
+                    "set": false,
+                    "infinite": false,
+                    "number": 0
+                },
+                "task": ""
+            },
+            "association": {
+                "account": "mila",
+                "cluster": "mila",
+                "partition": "",
+                "user": "masterkohga"
+            },
+            "block": "",
+            "cluster": "mila",
+            "constraints": "x86_64&(32gb|48gb)",
+            "container": "",
+            "derived_exit_code": {
+                "status": "SUCCESS",
+                "return_code": 0
+            },
+            "time": {
+                "elapsed": 83853331,
+                "eligible": 1613725209,
+                "end": 0,
+                "start": 1613725209,
+                "submission": 1613725209,
+                "suspended": 0,
+                "system": {
+                    "seconds": 0,
+                    "microseconds": 0
+                },
+                "limit": {
+                    "set": true,
+                    "infinite": false,
+                    "number": 7200
+                },
+                "total": {
+                    "seconds": 0,
+                    "microseconds": 0
+                },
+                "user": {
+                    "seconds": 0,
+                    "microseconds": 0
+                }
+            },
+            "exit_code": {
+                "status": "SUCCESS",
+                "return_code": 0
+            },
+            "extra": "",
+            "failed_node": "",
+            "flags": [
+                "STARTED_ON_SUBMIT"
+            ],
+            "group": null,
+            "het": {
+                "job_id": 0,
+                "job_offset": {
+                    "set": false,
+                    "infinite": false,
+                    "number": 0
+                }
+            },
+            "job_id": 4,
+            "name": "sh",
+            "licenses": "",
+            "mcs": {
+                "label": ""
+            },
+            "nodes": "mila02",
+            "partition": "main",
+            "hold": false,
+            "priority": {
+                "set": true,
+                "infinite": false,
+                "number": 499522
+            },
+            "qos": "normal",
+            "required": {
+                "CPUs": 4,
+                "memory_per_cpu": {
+                    "set": false,
+                    "infinite": false,
+                    "number": 0
+                },
+                "memory_per_node": {
+                    "set": true,
+                    "infinite": false,
+                    "number": 32768
+                },
+                "memory": 32768
+            },
+            "kill_request_user": "",
+            "reservation": {
+                "id": 0,
+                "name": ""
+            },
+            "script": "",
+            "state": {
+                "current": "RUNNING",
+                "reason": "None"
+            },
+            "steps": [],
+            "submit_line": "",
+            "tres": {
+                "allocated": [
+                    {
+                        "type": "cpu",
+                        "name": "",
+                        "id": 1,
+                        "count": 4
+                    },
+                    {
+                        "type": "mem",
+                        "name": "",
+                        "id": 2,
+                        "count": 32768
+                    },
+                    {
+                        "type": "energy",
+                        "name": "",
+                        "id": 3,
+                        "count": -2
+                    },
+                    {
+                        "type": "node",
+                        "name": "",
+                        "id": 4,
+                        "count": 1
+                    },
+                    {
+                        "type": "billing",
+                        "name": "",
+                        "id": 5,
+                        "count": 3
+                    },
+                    {
+                        "type": "gres",
+                        "name": "gpu",
+                        "id": 1001,
+                        "count": 2
+                    }
+                ],
+                "requested": [
+                    {
+                        "type": "cpu",
+                        "name": "",
+                        "id": 1,
+                        "count": 4
+                    },
+                    {
+                        "type": "mem",
+                        "name": "",
+                        "id": 2,
+                        "count": 32768
+                    },
+                    {
+                        "type": "node",
+                        "name": "",
+                        "id": 4,
+                        "count": 1
+                    },
+                    {
+                        "type": "billing",
+                        "name": "",
+                        "id": 5,
+                        "count": 3
+                    },
+                    {
+                        "type": "gres",
+                        "name": "gpu",
+                        "id": 1001,
+                        "count": 2
+                    }
+                ]
+            },
+            "used_gres": "",
+            "user": "masterkohga",
+            "wckey": {
+                "wckey": "",
+                "flags": []
+            },
+            "working_directory": "/home/mila/m/masterkohga"
+        }
+    ],
+    "warnings": [],
+    "errors": []
+}

--- a/tests/functional/jobs/test_func_sacct.py
+++ b/tests/functional/jobs/test_func_sacct.py
@@ -830,20 +830,14 @@ def test_cli_ignore_stats(
     else:
         assert mock_compute_job_statistics.called >= 1
 
+
 @pytest.mark.usefixtures("standard_config")
 @pytest.mark.parametrize(
     "sacct_outputs",
-    [
-        "slurm_21_8_8.json",
-        "slurm_22_5_9.json",
-        "slurm_23_2_6.json",      
-    ],
+    ["slurm_21_8_8.json", "slurm_22_5_9.json", "slurm_23_2_6.json"],
 )
 def test_parse_sacct_slurm_versions(sacct_outputs, scraper):
     file = Path(__file__).parent / "sacct_outputs" / sacct_outputs
     scraper.results = json.load(open(file, "r", encoding="utf8"))
-    #with caplog.at_level("WARNING"):
     jobs = list(scraper)
-
     assert len(jobs) == 1
-     

--- a/tests/functional/jobs/test_func_sacct.py
+++ b/tests/functional/jobs/test_func_sacct.py
@@ -242,7 +242,7 @@ def test_scraper_with_malformed_cache(test_config, remote, scraper, caplog):
 
     channel = remote.expect(
         host="patate",
-        cmd="/opt/slurm/bin/sacct  -X -S '2023-02-14T00:00' -E '2023-02-15T00:00' --json",
+        cmd="/opt/slurm/bin/sacct  -X -S '2023-02-14T00:00' -E '2023-02-15T00:00' --allusers --json",
         out=b"{}",
     )
 
@@ -261,7 +261,7 @@ def test_sacct_bin_and_accounts(test_config, remote):
     )
     channel = remote.expect(
         host="patate",
-        cmd="/opt/software/slurm/bin/sacct -A rrg-bonhomme-ad_gpu,rrg-bonhomme-ad_cpu,def-bonhomme_gpu,def-bonhomme_cpu -X -S '2023-02-14T00:00' -E '2023-02-15T00:00' --json",
+        cmd="/opt/software/slurm/bin/sacct -A rrg-bonhomme-ad_gpu,rrg-bonhomme-ad_cpu,def-bonhomme_gpu,def-bonhomme_cpu -X -S '2023-02-14T00:00' -E '2023-02-15T00:00' --allusers --json",
         out=b'{"jobs": []}',
     )
 
@@ -278,7 +278,7 @@ def test_stdout_message_before_json(
 ):
     channel = remote.expect(
         host="raisin",
-        cmd="/opt/slurm/bin/sacct  -X -S '2023-02-15T00:00' -E '2023-02-16T00:00' --json",
+        cmd="/opt/slurm/bin/sacct  -X -S '2023-02-15T00:00' -E '2023-02-16T00:00' --allusers --json",
         out=f"Welcome on raisin,\nThe sweetest supercomputer in the world!\n{sacct_json}".encode(
             "utf-8"
         ),
@@ -319,7 +319,7 @@ def test_get_gpu_type_from_prometheus(
 ):
     channel = remote.expect(
         host="raisin",
-        cmd="/opt/slurm/bin/sacct  -X -S '2023-02-15T00:00' -E '2023-02-16T00:00' --json",
+        cmd="/opt/slurm/bin/sacct  -X -S '2023-02-15T00:00' -E '2023-02-16T00:00' --allusers --json",
         out=f"Welcome on raisin,\nThe sweetest supercomputer in the world!\n{sacct_json}".encode(
             "utf-8"
         ),
@@ -385,7 +385,7 @@ def test_get_gpu_type_without_prometheus(
 ):
     channel = remote.expect(
         host="raisin_no_prometheus",
-        cmd="/opt/slurm/bin/sacct  -X -S '2023-02-15T00:00' -E '2023-02-16T00:00' --json",
+        cmd="/opt/slurm/bin/sacct  -X -S '2023-02-15T00:00' -E '2023-02-16T00:00' --allusers --json",
         out=f"Welcome on raisin_no_prometheus,\nThe sweetest supercomputer in the world!\n{sacct_json}".encode(
             "utf-8"
         ),
@@ -432,7 +432,7 @@ def test_save_job(
 ):
     channel = remote.expect(
         host="raisin",
-        cmd="/opt/slurm/bin/sacct  -X -S '2023-02-15T00:00' -E '2023-02-16T00:00' --json",
+        cmd="/opt/slurm/bin/sacct  -X -S '2023-02-15T00:00' -E '2023-02-16T00:00' --allusers --json",
         out=sacct_json.encode("utf-8"),
     )
 
@@ -473,7 +473,7 @@ def test_update_job(
         host="raisin",
         commands=[
             Command(
-                cmd="/opt/slurm/bin/sacct  -X -S '2023-02-15T00:00' -E '2023-02-16T00:00' --json",
+                cmd="/opt/slurm/bin/sacct  -X -S '2023-02-15T00:00' -E '2023-02-16T00:00' --allusers --json",
                 out=sacct_json.encode("utf-8"),
             )
             for _ in range(2)
@@ -548,7 +548,7 @@ def test_save_preempted_job(
     test_config, sacct_json, remote, file_regression, cli_main, prom_custom_query_mock
 ):
     channel = remote.expect(
-        cmd="/opt/slurm/bin/sacct  -X -S '2023-02-15T00:00' -E '2023-02-16T00:00' --json",
+        cmd="/opt/slurm/bin/sacct  -X -S '2023-02-15T00:00' -E '2023-02-16T00:00' --allusers --json",
         host="raisin",
         out=sacct_json.encode("utf-8"),
     )
@@ -596,7 +596,7 @@ def test_multiple_dates(
                     "/opt/slurm/bin/sacct  -X "
                     f"-S '{job_submit_datetime.strftime('%Y-%m-%dT%H:%M')}' "
                     f"-E '{(job_submit_datetime + timedelta(days=1)).strftime('%Y-%m-%dT%H:%M')}' "
-                    "--json"
+                    "--allusers --json"
                 ),
                 out=create_sacct_json(
                     [
@@ -683,7 +683,7 @@ def test_multiple_clusters_and_dates(
     channel = remote.expect_sessions(
         _create_session(
             "raisin",
-            "/opt/slurm/bin/sacct  -X -S '{start}' -E '{end}' --json",
+            "/opt/slurm/bin/sacct  -X -S '{start}' -E '{end}' --allusers --json",
             datetimes=datetimes,
         ),
         _create_session(
@@ -691,7 +691,7 @@ def test_multiple_clusters_and_dates(
             (
                 "/opt/software/slurm/bin/sacct "
                 "-A rrg-bonhomme-ad_gpu,rrg-bonhomme-ad_cpu,def-bonhomme_gpu,def-bonhomme_cpu "
-                "-X -S '{start}' -E '{end}' --json"
+                "-X -S '{start}' -E '{end}' --allusers --json"
             ),
             datetimes=datetimes,
         ),
@@ -750,7 +750,7 @@ def test_multiple_clusters_and_dates(
 def test_job_tz(test_config, sacct_json, remote, cli_main, prom_custom_query_mock):
     channel = remote.expect(
         host="patate",
-        cmd="/opt/software/slurm/bin/sacct -A rrg-bonhomme-ad_gpu,rrg-bonhomme-ad_cpu,def-bonhomme_gpu,def-bonhomme_cpu -X -S '2023-02-15T00:00' -E '2023-02-16T00:00' --json",
+        cmd="/opt/software/slurm/bin/sacct -A rrg-bonhomme-ad_gpu,rrg-bonhomme-ad_cpu,def-bonhomme_gpu,def-bonhomme_cpu -X -S '2023-02-15T00:00' -E '2023-02-16T00:00' --allusers --json",
         out=sacct_json.encode("utf-8"),
     )
 

--- a/tests/functional/jobs/test_func_sacct.py
+++ b/tests/functional/jobs/test_func_sacct.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import copy
 import json
 from datetime import datetime, timedelta
+from pathlib import Path
 
 import pytest
 from fabric.testing.base import Command, Session
@@ -828,3 +829,21 @@ def test_cli_ignore_stats(
         assert mock_compute_job_statistics.called == 0
     else:
         assert mock_compute_job_statistics.called >= 1
+
+@pytest.mark.usefixtures("standard_config")
+@pytest.mark.parametrize(
+    "sacct_outputs",
+    [
+        "slurm_21_8_8.json",
+        "slurm_22_5_9.json",
+        "slurm_23_2_6.json",      
+    ],
+)
+def test_parse_sacct_slurm_versions(sacct_outputs, scraper):
+    file = Path(__file__).parent / "sacct_outputs" / sacct_outputs
+    scraper.results = json.load(open(file, "r", encoding="utf8"))
+    #with caplog.at_level("WARNING"):
+    jobs = list(scraper)
+
+    assert len(jobs) == 1
+     

--- a/tests/unittests/jobs/test_sacct.py
+++ b/tests/unittests/jobs/test_sacct.py
@@ -18,7 +18,7 @@ def test_SAcctScraper_fetch_raw(test_config, remote):
     )
     channel = remote.expect(
         host="patate",
-        cmd="sacct  -X -S '2023-02-28T00:00' -E '2023-03-01T00:00' --json",
+        cmd="sacct  -X -S '2023-02-28T00:00' -E '2023-03-01T00:00' --allusers --json",
         out=b"{}",
     )
     assert scraper.fetch_raw() == {}
@@ -33,11 +33,11 @@ def test_SAcctScraper_fetch_raw2(test_config, remote):
     channel = remote.expect(
         commands=[
             Command(
-                "sacct  -X -S '2023-02-28T00:00' -E '2023-03-01T00:00' --json",
+                "sacct  -X -S '2023-02-28T00:00' -E '2023-03-01T00:00' --allusers --json",
                 out=b"{}",
             ),
             Command(
-                "sacct  -X -S '2023-02-28T00:00' -E '2023-03-01T00:00' --json",
+                "sacct  -X -S '2023-02-28T00:00' -E '2023-03-01T00:00' --allusers --json",
                 out=b'{ "value": 2 }',
             ),
         ]
@@ -69,11 +69,11 @@ def test_SAcctScraper_get_cache(test_config, remote):
     channel = remote.expect(
         commands=[
             Command(
-                f"sacct  -X -S '{yesterday.strftime(fmt)}' -E '{today.strftime(fmt)}' --json",
+                f"sacct  -X -S '{yesterday.strftime(fmt)}' -E '{today.strftime(fmt)}' --allusers --json",
                 out=b'{"value": 2}',
             ),
             Command(
-                f"sacct  -X -S '{today.strftime(fmt)}' -E '{tomorrow.strftime(fmt)}' --json",
+                f"sacct  -X -S '{today.strftime(fmt)}' -E '{tomorrow.strftime(fmt)}' --allusers --json",
                 out=b'{"value": 2}',
             ),
         ]


### PR DESCRIPTION
New slurm version (23.02.6) now requires the argument `--allusers` with `--json` otherwise it only returns jobs from the current user.