### PR TITLE
fix issue https://github.com/mila-iqia/SARC/issues/83 : 

### DIFF
--- a/sarc/ldap/read_mila_ldap.py
+++ b/sarc/ldap/read_mila_ldap.py
@@ -259,7 +259,9 @@ def client_side_user_updates(LD_users_DB, LD_users_LDAP):
             entry = DD_users_LDAP[meu]
             ## entry["some_unique_id_or_whatever"] = None
         else:
-            entry = DD_users_DB[meu]
+            # User is in both DB and LDAP. We'll consider the LDAP more up-to-date.
+            entry = DD_users_LDAP[meu]
+            
 
         assert "status" in entry  # sanity check
         LD_users_to_update_or_insert.append(entry)

--- a/sarc/ldap/read_mila_ldap.py
+++ b/sarc/ldap/read_mila_ldap.py
@@ -251,15 +251,12 @@ def client_side_user_updates(LD_users_DB, LD_users_LDAP):
             # Let's mark it as archived.
             entry = DD_users_DB[meu]
             entry["status"] = "archived"
-        elif meu not in DD_users_DB and meu in DD_users_LDAP:
-            # User is not in DB but is in the LDAP. That's a new entry!
+        else:
+            # either User is not in DB but is in the LDAP (new entry)
+            # or User is in both DB and LDAP. We'll consider the LDAP more up-to-date.
             # If you need to enter some fields for the first time
             # when entering a new user, do it here.
             # As of right now, we have no need to do that.
-            entry = DD_users_LDAP[meu]
-            ## entry["some_unique_id_or_whatever"] = None
-        else:
-            # User is in both DB and LDAP. We'll consider the LDAP more up-to-date.
             entry = DD_users_LDAP[meu]
 
         assert "status" in entry  # sanity check

--- a/sarc/ldap/read_mila_ldap.py
+++ b/sarc/ldap/read_mila_ldap.py
@@ -261,7 +261,6 @@ def client_side_user_updates(LD_users_DB, LD_users_LDAP):
         else:
             # User is in both DB and LDAP. We'll consider the LDAP more up-to-date.
             entry = DD_users_LDAP[meu]
-            
 
         assert "status" in entry  # sanity check
         LD_users_to_update_or_insert.append(entry)


### PR DESCRIPTION
write ldap data in db even if db has a ldap record; we consider ldap data more up to date.

This fixex issue #83 