### PR TITLE
Fix supervisor/student pairing bug during LDAP import

### DIFF
--- a/sarc/ldap/supervisor.py
+++ b/sarc/ldap/supervisor.py
@@ -38,8 +38,8 @@ def extract_groups(member_of: list[str]):
         if m := re.match(r"^cn=(.+?),.*", e):
             if m.group(1) in ["mila-core-profs", "mila-profs", "core-academic-member"]:
                 is_core = True
+                is_student = False
 
-            is_student = False
             groups.append(m.group(1))
             continue
 

--- a/sarc/ldap/supervisor.py
+++ b/sarc/ldap/supervisor.py
@@ -193,11 +193,11 @@ def resolve_supervisors(
             exceptions,
         )
 
-        if result.is_prof and result.is_student:
-            errors.prof_and_student.append(result)
+        if result is None:
             continue
 
-        if result is None:
+        if result.is_prof and result.is_student:
+            errors.prof_and_student.append(result)
             continue
 
         index[result.ldap["mail"][0]] = result

--- a/tests/unittests/ldap/test_sync.py
+++ b/tests/unittests/ldap/test_sync.py
@@ -266,6 +266,18 @@ def test_student_and_prof():
     assert result is not None
     assert result.is_student and result.is_prof
 
+def test_student_and_groups():
+    person = make_student("supervisor", ["mcgill", "supervisor"])
+    person["memberOf"].append("cn=group,ou=Groups,dc=mila,dc=quebec")
+    result = _student_or_prof(
+        person,
+        dict(),
+        dict(),
+    )
+    assert result is not None
+    assert "group" in result.cn_groups
+    assert result.is_student
+    assert not result.is_prof
 
 def test_student_or_prof_exception_student_is_prof():
     result = _student_or_prof(

--- a/tests/unittests/ldap/test_sync.py
+++ b/tests/unittests/ldap/test_sync.py
@@ -266,6 +266,7 @@ def test_student_and_prof():
     assert result is not None
     assert result.is_student and result.is_prof
 
+
 def test_student_and_groups():
     person = make_student("supervisor", ["mcgill", "supervisor"])
     person["memberOf"].append("cn=group,ou=Groups,dc=mila,dc=quebec")
@@ -278,6 +279,7 @@ def test_student_and_groups():
     assert "group" in result.cn_groups
     assert result.is_student
     assert not result.is_prof
+
 
 def test_student_or_prof_exception_student_is_prof():
     result = _student_or_prof(


### PR DESCRIPTION
Un stupide bug d'indentation faisait ignorer une bonne partie des étudiants.