### PR TITLE
Improve speed of stats computation

### DIFF
--- a/tests/unittests/jobs/test_series.py
+++ b/tests/unittests/jobs/test_series.py
@@ -1,7 +1,7 @@
-import math
-from datetime import datetime, timedelta
-import time
 import itertools
+import math
+import time
+from datetime import datetime, timedelta
 
 import pandas
 import pytest

--- a/tests/unittests/jobs/test_series.py
+++ b/tests/unittests/jobs/test_series.py
@@ -1,5 +1,7 @@
 import math
 from datetime import datetime, timedelta
+import time
+import itertools
 
 import pandas
 import pytest
@@ -100,3 +102,47 @@ def test_compute_job_statistics_from_dataframe_unused_count(nprops, threshold):
         assert stats == {"mean": sum(valid) / nvalid, "unused": nunused}
     else:
         assert math.isnan(stats["mean"]) and stats["unused"] == nunused
+
+@pytest.mark.parametrize(["nprops", "threshold"], [[1, 0.0], [2, 0.2], [2, 2.0]])
+@pytest.mark.timeout(2)
+def test_compute_job_statistics_from_dataframe_unused_count_timing(nprops, threshold):
+    values = [0.5, 0.1, 1.0]
+    assert nprops in (1, 2)
+
+    n_data_points = 1000
+    n_instances = 10
+    n_cores = 10
+    rows = []
+    if nprops == 2:
+        n_cores = 10
+    else:
+        n_cores = 1
+
+    timestamps = pandas.date_range(
+        datetime(2023, 1, 1), periods=n_data_points, freq="30s"
+    )
+
+    for node, core, value in itertools.product(
+        range(n_instances), range(n_cores), range(n_data_points)
+    ):
+        value_index = (node * core + node) % len(values)
+        rows.append(
+            {
+                "instance": "cn-c{node:03}",
+                "core": core,
+                "value": values[value_index],
+                "timestamp": timestamps[value],
+            }
+        )
+
+    df = pandas.DataFrame(rows)
+    df = df.sort_values(by="timestamp")
+
+    start = time.perf_counter()
+    compute_job_statistics_from_dataframe(
+        df,
+        {"mean": DataFrame.mean},
+        unused_threshold=threshold,
+    )
+    end = time.perf_counter()
+    print(timedelta(seconds=end - start))

--- a/tests/unittests/jobs/test_series.py
+++ b/tests/unittests/jobs/test_series.py
@@ -103,6 +103,7 @@ def test_compute_job_statistics_from_dataframe_unused_count(nprops, threshold):
     else:
         assert math.isnan(stats["mean"]) and stats["unused"] == nunused
 
+
 @pytest.mark.parametrize(["nprops", "threshold"], [[1, 0.0], [2, 0.2], [2, 2.0]])
 @pytest.mark.timeout(2)
 def test_compute_job_statistics_from_dataframe_unused_count_timing(nprops, threshold):


### PR DESCRIPTION
pd.apply is horribly slow. Using pd.merge and row-wise select is about 1000x faster.

Added as well a unittest to make sure we do not degrade speed significantly. On my computer it takes 0.02s to run. The timeout of the test is 2s. Previous implementation required 30s to run the test.