### PR TITLE
improve prometheus gpu_type fetching

### DIFF
--- a/sarc/jobs/sacct.py
+++ b/sarc/jobs/sacct.py
@@ -286,7 +286,6 @@ def update_allocated_gpu_type(cluster: ClusterConfig, entry: SlurmJob) -> Option
         output = get_job_time_series(
             job=entry,
             metric="slurm_job_utilization_gpu_memory",
-            max_points=1,
             dataframe=False,
         )
         if output:


### PR DESCRIPTION
Fixes the `update_allocated_gpu_type` function to increase gpu_type detection

Tested on 2023-09-01 - 2023-11-27, results:

From 60696 jobs with prometheus stats:
38793 jobs with gpu_type detected
4709 jobs with gpu_type that were not detected before
0 regressions (jobs with gpu_type that were detected before but not anymore)
21903 jobs with no gpu_type detected 