### PR TITLE
fake_mymila_data

### DIFF
--- a/sarc/jobs/node_gpu_mapping.py
+++ b/sarc/jobs/node_gpu_mapping.py
@@ -4,6 +4,7 @@ to map a cluster's node name to GPU type
 by parsing TXT files containing node descriptions like:
     NodeName=<nodes_description> Gres=<gpu-type> ...
 """
+
 import json
 import os
 

--- a/sarc/jobs/sacct.py
+++ b/sarc/jobs/sacct.py
@@ -190,9 +190,9 @@ class SAcctScraper:
                 end_time=end_time,
                 elapsed_time=elapsed_time,
                 partition=entry["partition"],
-                nodes=sorted(expand_hostlist(nodes))
-                if nodes != "None assigned"
-                else [],
+                nodes=(
+                    sorted(expand_hostlist(nodes)) if nodes != "None assigned" else []
+                ),
                 constraints=entry["constraints"],
                 priority=entry["priority"],
                 qos=entry["qos"],
@@ -219,9 +219,9 @@ class SAcctScraper:
                 end_time=end_time,
                 elapsed_time=elapsed_time,
                 partition=entry["partition"],
-                nodes=sorted(expand_hostlist(nodes))
-                if nodes != "None assigned"
-                else [],
+                nodes=(
+                    sorted(expand_hostlist(nodes)) if nodes != "None assigned" else []
+                ),
                 constraints=entry["constraints"],
                 priority=entry["priority"]["number"],
                 qos=entry["qos"],

--- a/sarc/ldap/api.py
+++ b/sarc/ldap/api.py
@@ -3,6 +3,7 @@ Implements the API as it was defined in
 https://mila-iqia.atlassian.net/wiki/spaces/IDT/pages/2190737548/Planification
 
 """
+
 from __future__ import annotations
 
 from typing import Optional

--- a/sarc/ldap/read_mila_ldap.py
+++ b/sarc/ldap/read_mila_ldap.py
@@ -134,6 +134,7 @@ they are structured as follows:
     }
 
 """
+
 import json
 import os
 import ssl
@@ -215,9 +216,11 @@ def process_user(user_raw: dict) -> dict:
         "display_name": user_raw["displayName"][0],
         "supervisor": supervisor if supervisor else None,
         "co_supervisor": cosupervisor if cosupervisor else None,
-        "status": "disabled"
-        if (user_raw["suspended"][0] in ["True", "true", True])
-        else "enabled",
+        "status": (
+            "disabled"
+            if (user_raw["suspended"][0] in ["True", "true", True])
+            else "enabled"
+        ),
     }
     assert user_raw["mail"][0].startswith(user_raw["googleUid"][0])
     assert user_raw["mail"][0].startswith(user_raw["uid"][0])

--- a/sarc/storage/mila.py
+++ b/sarc/storage/mila.py
@@ -1,6 +1,7 @@
 """
 Fetching and parsing code specific to the mila cluster
 """
+
 from datetime import datetime
 
 from tqdm import tqdm

--- a/tests/functional/cli/acquire/test_acquire_users.py
+++ b/tests/functional/cli/acquire/test_acquire_users.py
@@ -55,12 +55,15 @@ def fake_raw_ldap_data(nbr_users=10):
         ]
     )
 
+
 import random
-def fake_mymila_data(nbr_users=10,nbr_profs=5):
+
+
+def fake_mymila_data(nbr_users=10, nbr_profs=5):
     """
     Return a deterministically-generated list of fake MyMila users just as
     they would be returned by the function `load_mymila` (yet to be developped).
-    This is used for mocking the reading of a CSV file, since we don't expect 
+    This is used for mocking the reading of a CSV file, since we don't expect
     being able to read directly from the database itself in the short term.
 
     Records must have some matching points with the fake LDAP data, to allow
@@ -101,9 +104,9 @@ def fake_mymila_data(nbr_users=10,nbr_profs=5):
         is_prof = i < nbr_profs
         if is_prof:
             membership_types = [
-                'Permanent HQP',
-                'Visiting Researcher',
-                'Collaborating Researcher',
+                "Permanent HQP",
+                "Visiting Researcher",
+                "Collaborating Researcher",
             ]
             affiliation_types = [
                 "Collaborating Alumni",
@@ -111,7 +114,7 @@ def fake_mymila_data(nbr_users=10,nbr_profs=5):
                 "HQP - Postdoctorate",
                 "visiting researcher",
                 "",
-            ]   
+            ]
             supervisors = [""]
             current_university_title = [
                 "Canada Research Chair (Tier 2) and Assistant Professor",
@@ -122,8 +125,8 @@ def fake_mymila_data(nbr_users=10,nbr_profs=5):
 
         else:
             membership_types = [
-                'Research intern',
-                '',
+                "Research intern",
+                "",
             ]
             affiliation_types = [
                 "HQP - DESS",
@@ -133,8 +136,10 @@ def fake_mymila_data(nbr_users=10,nbr_profs=5):
                 "HQP - Undergraduate",
                 "Research Intern",
                 "",
-            ]   
-            supervisors = [f"John Smith{i:03d}" for i in range(nbr_profs)]  # 'nbr_profs' first names for profs
+            ]
+            supervisors = [
+                f"John Smith{i:03d}" for i in range(nbr_profs)
+            ]  # 'nbr_profs' first names for profs
             current_university_title = [
                 "",
             ]
@@ -142,57 +147,59 @@ def fake_mymila_data(nbr_users=10,nbr_profs=5):
         first_name = "John"
         last_name = f"Smith{i:03d}"
         email = f"john.smith{i:03d}@mila.quebec"
-        
+
         return {
-            'Profile Type' : '',
-            'Applicant Type' : '',
-            'internal id' : '',
-            'Mila Number' : '',
-            'Membership Type' : membership_types[i % len(membership_types)],
-            'Affiliation type' : affiliation_types[i % len(affiliation_types)],
-            'Assistant email' : '',
-            'Preferred email' : '',
-            'Faculty affiliated' : faculty_affiliated[i % len(faculty_affiliated)],
-            'Department affiliated' : '',
-            'ID affiliated' : '',
-            'Affiliated university 2' : '',
-            'Second affiliated university' : '',
-            'Affiliated university 3' : '',
-            'Third affiliated university' : '',
-            'Program of study' : program_of_study[i % len(program_of_study)],
-            'GitHub username' : '',
-            'Google Scholar profile' : '',
-            'Cluster access' : '',
-            'Access privileges' : '',
-            'Status' : status[i % len(status)],
-            'Membership Type.1' : '',
-            'Affiliation type.1' : '',
-            'Last Name' : first_name,
-            'First Name' : last_name,
-            'Preferred First Name' : first_name,
-            'Email' : email,
-            'Supervisor Principal' : supervisors[i % len(supervisors)],
-            'Co-Supervisor' : supervisors[(i+1) % len(supervisors)],
-            'Start date of studies' : '01/01/2022',
-            'End date of studies' : '31/12/2027',
-            'Start date of visit-internship' : '',
-            'End date of visit-internship' : '',
-            'Affiliated university' : affiliated_university[i % len(affiliated_university)],
-            'Current university title' : current_university_title[i % len(current_university_title)],
-            'Start date of academic nomination' : '01/01/2022',
-            'End date of academic nomination' : '31/12/2027' if random.choice([True, False]) else '',
-            'Alliance-DRAC account' : '',
-            'MILA Email' : email,
-            'Start Date with MILA' : '01/01/2022',
-            'End Date with MILA' : '31/12/2027' if random.choice([True, False]) else '',
-            'Type of membership' : '',
+            "Profile Type": "",
+            "Applicant Type": "",
+            "internal id": "",
+            "Mila Number": "",
+            "Membership Type": membership_types[i % len(membership_types)],
+            "Affiliation type": affiliation_types[i % len(affiliation_types)],
+            "Assistant email": "",
+            "Preferred email": "",
+            "Faculty affiliated": faculty_affiliated[i % len(faculty_affiliated)],
+            "Department affiliated": "",
+            "ID affiliated": "",
+            "Affiliated university 2": "",
+            "Second affiliated university": "",
+            "Affiliated university 3": "",
+            "Third affiliated university": "",
+            "Program of study": program_of_study[i % len(program_of_study)],
+            "GitHub username": "",
+            "Google Scholar profile": "",
+            "Cluster access": "",
+            "Access privileges": "",
+            "Status": status[i % len(status)],
+            "Membership Type.1": "",
+            "Affiliation type.1": "",
+            "Last Name": first_name,
+            "First Name": last_name,
+            "Preferred First Name": first_name,
+            "Email": email,
+            "Supervisor Principal": supervisors[i % len(supervisors)],
+            "Co-Supervisor": supervisors[(i + 1) % len(supervisors)],
+            "Start date of studies": "01/01/2022",
+            "End date of studies": "31/12/2027",
+            "Start date of visit-internship": "",
+            "End date of visit-internship": "",
+            "Affiliated university": affiliated_university[
+                i % len(affiliated_university)
+            ],
+            "Current university title": current_university_title[
+                i % len(current_university_title)
+            ],
+            "Start date of academic nomination": "01/01/2022",
+            "End date of academic nomination": "31/12/2027"
+            if random.choice([True, False])
+            else "",
+            "Alliance-DRAC account": "",
+            "MILA Email": email,
+            "Start Date with MILA": "01/01/2022",
+            "End Date with MILA": "31/12/2027" if random.choice([True, False]) else "",
+            "Type of membership": "",
         }
-        
-    return list(
-        [
-            mymila_entry(i) for i in range(nbr_users)
-        ]
-    )
+
+    return list([mymila_entry(i) for i in range(nbr_users)])
 
 
 class MyStringIO(StringIO):

--- a/tests/functional/cli/acquire/test_acquire_users.py
+++ b/tests/functional/cli/acquire/test_acquire_users.py
@@ -55,6 +55,145 @@ def fake_raw_ldap_data(nbr_users=10):
         ]
     )
 
+import random
+def fake_mymila_data(nbr_users=10,nbr_profs=5):
+    """
+    Return a deterministically-generated list of fake MyMila users just as
+    they would be returned by the function `load_mymila` (yet to be developped).
+    This is used for mocking the reading of a CSV file, since we don't expect 
+    being able to read directly from the database itself in the short term.
+
+    Records must have some matching points with the fake LDAP data, to allow
+    for matching to be tested.
+
+    Returns a list of dictionaries, easy to convert to a dataframe.
+    """
+
+    faculty_affiliated = [
+        "Computer Science and Operations Research",
+        "Electrical and Computer Engineering",
+        "Mathematics and Statistics",
+        "Physics",
+        "Psychology",
+        "Other",
+        "",
+    ]
+    program_of_study = [
+        "Computer Science",
+        "Doctorat en Informatique",
+        "",
+    ]
+    status = [
+        "Active",
+        "Inactive",
+        "",
+    ]
+    affiliated_university = [
+        "McGill",
+        "UdeM",
+        "Samsung SAIT",
+        "",
+    ]
+
+    # by convention, first 'nbr_profs' names will be professors and the rest students
+    def mymila_entry(i: int):
+        # 2 different types of entries: prof and student
+        is_prof = i < nbr_profs
+        if is_prof:
+            membership_types = [
+                'Permanent HQP',
+                'Visiting Researcher',
+                'Collaborating Researcher',
+            ]
+            affiliation_types = [
+                "Collaborating Alumni",
+                "Collaborating researcher",
+                "HQP - Postdoctorate",
+                "visiting researcher",
+                "",
+            ]   
+            supervisors = [""]
+            current_university_title = [
+                "Canada Research Chair (Tier 2) and Assistant Professor",
+                "Assistant Professor, School of Computer Science",
+                "Professeur sous octrois agrégé / Associate Research Professor",
+                "",
+            ]
+
+        else:
+            membership_types = [
+                'Research intern',
+                '',
+            ]
+            affiliation_types = [
+                "HQP - DESS",
+                "HQP - Master's Research",
+                "HQP - PhD",
+                "HQP - Professional Master's",
+                "HQP - Undergraduate",
+                "Research Intern",
+                "",
+            ]   
+            supervisors = [f"John Smith{i:03d}" for i in range(nbr_profs)]  # 'nbr_profs' first names for profs
+            current_university_title = [
+                "",
+            ]
+
+        first_name = "John"
+        last_name = f"Smith{i:03d}"
+        email = f"john.smith{i:03d}@mila.quebec"
+        
+        return {
+            'Profile Type' : '',
+            'Applicant Type' : '',
+            'internal id' : '',
+            'Mila Number' : '',
+            'Membership Type' : membership_types[i % len(membership_types)],
+            'Affiliation type' : affiliation_types[i % len(affiliation_types)],
+            'Assistant email' : '',
+            'Preferred email' : '',
+            'Faculty affiliated' : faculty_affiliated[i % len(faculty_affiliated)],
+            'Department affiliated' : '',
+            'ID affiliated' : '',
+            'Affiliated university 2' : '',
+            'Second affiliated university' : '',
+            'Affiliated university 3' : '',
+            'Third affiliated university' : '',
+            'Program of study' : program_of_study[i % len(program_of_study)],
+            'GitHub username' : '',
+            'Google Scholar profile' : '',
+            'Cluster access' : '',
+            'Access privileges' : '',
+            'Status' : status[i % len(status)],
+            'Membership Type.1' : '',
+            'Affiliation type.1' : '',
+            'Last Name' : first_name,
+            'First Name' : last_name,
+            'Preferred First Name' : first_name,
+            'Email' : email,
+            'Supervisor Principal' : supervisors[i % len(supervisors)],
+            'Co-Supervisor' : supervisors[(i+1) % len(supervisors)],
+            'Start date of studies' : '01/01/2022',
+            'End date of studies' : '31/12/2027',
+            'Start date of visit-internship' : '',
+            'End date of visit-internship' : '',
+            'Affiliated university' : affiliated_university[i % len(affiliated_university)],
+            'Current university title' : current_university_title[i % len(current_university_title)],
+            'Start date of academic nomination' : '01/01/2022',
+            'End date of academic nomination' : '31/12/2027' if random.choice([True, False]) else '',
+            'Alliance-DRAC account' : '',
+            'MILA Email' : email,
+            'Start Date with MILA' : '01/01/2022',
+            'End Date with MILA' : '31/12/2027' if random.choice([True, False]) else '',
+            'Type of membership' : '',
+        }
+        
+    return list(
+        [
+            mymila_entry(i) for i in range(nbr_users)
+        ]
+    )
+
 
 class MyStringIO(StringIO):
     """

--- a/tests/functional/cli/acquire/test_acquire_users.py
+++ b/tests/functional/cli/acquire/test_acquire_users.py
@@ -58,6 +58,7 @@ def fake_raw_ldap_data(nbr_users=10):
 
 import random
 
+
 def fake_mymila_data(nbr_users=10, nbr_profs=5):
     """
     Return a deterministically-generated list of fake MyMila users just as

--- a/tests/functional/cli/acquire/test_acquire_users.py
+++ b/tests/functional/cli/acquire/test_acquire_users.py
@@ -58,17 +58,14 @@ def fake_raw_ldap_data(nbr_users=10):
 
 import random
 
-
 def fake_mymila_data(nbr_users=10, nbr_profs=5):
     """
     Return a deterministically-generated list of fake MyMila users just as
     they would be returned by the function `load_mymila` (yet to be developped).
     This is used for mocking the reading of a CSV file, since we don't expect
     being able to read directly from the database itself in the short term.
-
     Records must have some matching points with the fake LDAP data, to allow
     for matching to be tested.
-
     Returns a list of dictionaries, easy to convert to a dataframe.
     """
 
@@ -178,8 +175,8 @@ def fake_mymila_data(nbr_users=10, nbr_profs=5):
             "Email": email,
             "Supervisor Principal": supervisors[i % len(supervisors)],
             "Co-Supervisor": supervisors[(i + 1) % len(supervisors)],
-            "Start date of studies": "01/01/2022",
-            "End date of studies": "31/12/2027",
+            "Start date of studies": date(year=2022, month=1, day=1),
+            "End date of studies": date(year=2027, month=12, day=31),
             "Start date of visit-internship": "",
             "End date of visit-internship": "",
             "Affiliated university": affiliated_university[
@@ -188,18 +185,16 @@ def fake_mymila_data(nbr_users=10, nbr_profs=5):
             "Current university title": current_university_title[
                 i % len(current_university_title)
             ],
-            "Start date of academic nomination": "01/01/2022",
-            "End date of academic nomination": "31/12/2027"
-            if random.choice([True, False])
-            else "",
+            "Start date of academic nomination": date(2022, 1, 1),
+            "End date of academic nomination": [date(2027, 12, 31), None][i % 2],
             "Alliance-DRAC account": "",
             "MILA Email": email,
-            "Start Date with MILA": "01/01/2022",
-            "End Date with MILA": "31/12/2027" if random.choice([True, False]) else "",
+            "Start Date with MILA": date(2022, 1, 1),
+            "End Date with MILA": [date(2027, 12, 31), None][i % 2],
             "Type of membership": "",
         }
 
-    return list([mymila_entry(i) for i in range(nbr_users)])
+    return pd.DataFrame(list([mymila_entry(i) for i in range(nbr_users)]))
 
 
 class MyStringIO(StringIO):

--- a/tests/functional/diskusage/test_drac_fetch_diskusage_report.py
+++ b/tests/functional/diskusage/test_drac_fetch_diskusage_report.py
@@ -1,6 +1,7 @@
 """
 tests the scraping of disk usage report on DRAC clusters
 """
+
 from pathlib import Path
 
 import pytest


### PR DESCRIPTION
La fonction génère une liste de dictionnaires. 
On peut très facilement le transformer en DataFrame via `df=pd.DataFrame(fake_mymila_data(...))` pour obtenir le même objet qu'en chargeant directement le csv avec `df = pd.read_csv('MonMilaFakeData.csv')` 

Par défaut, les 5 premier users sont des profs et n'ont pas de superviseurs, les suivants sont des etudiants et ont des superviseurs/co-superviseur parmi les 5 premier.

Les noms d'utilisateurs et emails sont conformes à ceux générés par la fonction `fake_raw_ldap_data` de manière à pouvoir faire des tests de matching entre ces deux sources de données.