### PR TITLE
Test supervisor and co-supervisor import

### DIFF
--- a/sarc/ldap/acquire.py
+++ b/sarc/ldap/acquire.py
@@ -30,6 +30,21 @@ def run(prompt=False):
 
     LD_users = fetch_mymila(cfg, LD_users)
 
+    # For each supervisor or co-supervisor, look for a mila_email_username
+    # matching the display name. If None has been found, the previous value remains
+    for supervisor_key in ["supervisor", "co_supervisor"]:
+        for user in LD_users:
+            if (
+                supervisor_key in user
+                and user[supervisor_key] is not None
+                and not "@mila.quebec" in user[supervisor_key].lower()
+            ):
+                for potential_supervisor in LD_users:
+                    if potential_supervisor["display_name"] == user[supervisor_key]:
+                        user[supervisor_key] = potential_supervisor[
+                            "mila_email_username"
+                        ]
+
     # Match DRAC/CC to mila accounts
     DLD_data = sarc.account_matching.make_matches.load_data_from_files(
         {

--- a/sarc/ldap/mymila.py
+++ b/sarc/ldap/mymila.py
@@ -57,9 +57,13 @@ def to_records(df):
 def combine(LD_users, mymila_data):
     if not mymila_data.empty:
         df_users = pd.DataFrame(LD_users)
+        # Set the empty values to NA
+        df_users = df_users.where((pd.notnull(df_users)) & (df_users != ""), pd.NA)
 
         # Preprocess
         mymila_data = mymila_data.rename(columns={"MILA Email": "mila_email_username"})
+        # Set the empty values to NA
+        mymila_data = mymila_data.where((pd.notnull(mymila_data)) & (mymila_data != ""), pd.NA)
 
         if LD_users:
             df = pd.merge(df_users, mymila_data, on="mila_email_username", how="outer")

--- a/sarc/ldap/mymila.py
+++ b/sarc/ldap/mymila.py
@@ -63,7 +63,9 @@ def combine(LD_users, mymila_data):
         # Preprocess
         mymila_data = mymila_data.rename(columns={"MILA Email": "mila_email_username"})
         # Set the empty values to NA
-        mymila_data = mymila_data.where((pd.notnull(mymila_data)) & (mymila_data != ""), pd.NA)
+        mymila_data = mymila_data.where(
+            (pd.notnull(mymila_data)) & (mymila_data != ""), pd.NA
+        )
 
         if LD_users:
             df = pd.merge(df_users, mymila_data, on="mila_email_username", how="outer")

--- a/tests/common/sarc_mocks.py
+++ b/tests/common/sarc_mocks.py
@@ -203,25 +203,59 @@ def mymila_entry_builder(nbr_profs=5, hardcoded_values_by_user={}):
                 "Status": _define_value(i, "Status", status[i % len(status)]),
                 "Last Name": _define_value(i, "Last Name", first_name),
                 "First Name": _define_value(i, "First Name", last_name),
-                "Preferred First Name": _define_value(i, "Preferred First Name", first_name),
+                "Preferred First Name": _define_value(
+                    i, "Preferred First Name", first_name
+                ),
                 "MILA Email": _define_value(i, "MILA Email", email),
-                "Start Date with MILA": _define_value(i, "Start Date with MILA", date(2022, 1, 1)),
-                "End Date with MILA": _define_value(i, "End Date with MILA", [date(2027, 12, 31), None][i % 2]),
-                "Supervisor Principal": _define_value(i, "Supervisor Principal", supervisors[i % len(supervisors)]),
-                "Co-Supervisor": _define_value(i, "Co-Supervisor", supervisors[(i + 1) % len(supervisors)]),
+                "Start Date with MILA": _define_value(
+                    i, "Start Date with MILA", date(2022, 1, 1)
+                ),
+                "End Date with MILA": _define_value(
+                    i, "End Date with MILA", [date(2027, 12, 31), None][i % 2]
+                ),
+                "Supervisor Principal": _define_value(
+                    i, "Supervisor Principal", supervisors[i % len(supervisors)]
+                ),
+                "Co-Supervisor": _define_value(
+                    i, "Co-Supervisor", supervisors[(i + 1) % len(supervisors)]
+                ),
                 # Optional
-                "Membership Type": _define_value(i, "Membership Type", membership_types[i % len(membership_types)]),
-                "Affiliation type": _define_value(i, "Affiliation type", affiliation_types[i % len(affiliation_types)]),
-                "Faculty affiliated": _define_value(i, "Faculty affiliated", faculty_affiliated[i % len(faculty_affiliated)]),
-                "Program of study": _define_value(i, "Program of study", program_of_study[i % len(program_of_study)]),
-                "Start date of studies": _define_value(i, "Start date of studies", date(year=2022, month=1, day=1)),
-                "End date of studies": _define_value(i, "End date of studies", date(year=2027, month=12, day=31)),
-                "Affiliated university": _define_value(i, "Affiliated university", affiliated_university[
-                    i % len(affiliated_university)
-                ]),
-                "Current university title": _define_value(i, "Current university title", uni_title),
-                "Start date of academic nomination": _define_value(i, "Start date of academic nomination", date(2022, 1, 1)),
-                "End date of academic nomination": _define_value(i, "End date of academic nomination", [date(2027, 12, 31), None][i % 2]),
+                "Membership Type": _define_value(
+                    i, "Membership Type", membership_types[i % len(membership_types)]
+                ),
+                "Affiliation type": _define_value(
+                    i, "Affiliation type", affiliation_types[i % len(affiliation_types)]
+                ),
+                "Faculty affiliated": _define_value(
+                    i,
+                    "Faculty affiliated",
+                    faculty_affiliated[i % len(faculty_affiliated)],
+                ),
+                "Program of study": _define_value(
+                    i, "Program of study", program_of_study[i % len(program_of_study)]
+                ),
+                "Start date of studies": _define_value(
+                    i, "Start date of studies", date(year=2022, month=1, day=1)
+                ),
+                "End date of studies": _define_value(
+                    i, "End date of studies", date(year=2027, month=12, day=31)
+                ),
+                "Affiliated university": _define_value(
+                    i,
+                    "Affiliated university",
+                    affiliated_university[i % len(affiliated_university)],
+                ),
+                "Current university title": _define_value(
+                    i, "Current university title", uni_title
+                ),
+                "Start date of academic nomination": _define_value(
+                    i, "Start date of academic nomination", date(2022, 1, 1)
+                ),
+                "End date of academic nomination": _define_value(
+                    i,
+                    "End date of academic nomination",
+                    [date(2027, 12, 31), None][i % 2],
+                ),
                 "Email": _define_value(i, "Email", email),
             },
         )
@@ -243,13 +277,18 @@ def fake_member_of(index, count):
     }
     return member_of_config.get(index, [])
 
+
 def define_value(i, key, default_value, hardcoded_values_by_user):
-    """
-    """
+    """ """
 
-    return hardcoded_values_by_user[i][key] if i in hardcoded_values_by_user and key in hardcoded_values_by_user[i] else default_value
+    return (
+        hardcoded_values_by_user[i][key]
+        if i in hardcoded_values_by_user and key in hardcoded_values_by_user[i]
+        else default_value
+    )
 
-def fake_raw_ldap_data(nbr_users=10, hardcoded_values_by_user = {}):
+
+def fake_raw_ldap_data(nbr_users=10, hardcoded_values_by_user={}):
     """
     Return a deterministically-generated list of fake LDAP users just as
     they would be returned by the function `query_ldap`.
@@ -280,28 +319,42 @@ def fake_raw_ldap_data(nbr_users=10, hardcoded_values_by_user = {}):
     return list(
         [
             {
-                "apple-generateduid": _define_value(i, "apple-generateduid", ["AF54098F-29AE-990A-B1AC-F63F5A89B89"]),
-                "cn": _define_value(i, "cn", [f"john.smith{i:03d}", f"John Smith{i:03d}"]),
+                "apple-generateduid": _define_value(
+                    i, "apple-generateduid", ["AF54098F-29AE-990A-B1AC-F63F5A89B89"]
+                ),
+                "cn": _define_value(
+                    i, "cn", [f"john.smith{i:03d}", f"John Smith{i:03d}"]
+                ),
                 "departmentNumber": _define_value(i, "departmentNumber", []),
-                "displayName": _define_value(i, "displayName", [f"John Smith the {i:03d}rd"]),
+                "displayName": _define_value(
+                    i, "displayName", [f"John Smith the {i:03d}rd"]
+                ),
                 "employeeNumber": _define_value(i, "employeeNumber", []),
                 "employeeType": _define_value(i, "employeeType", []),
                 "gecos": _define_value(i, "gecos", [""]),
                 "gidNumber": _define_value(i, "gidNumber", [str(1500000001 + i)]),
                 "givenName": _define_value(i, "givenName", ["John"]),
                 "googleUid": _define_value(i, "googleUid", [f"john.smith{i:03d}"]),
-                "homeDirectory": _define_value(i, "homeDirectory", [f"/home/john.smith{i:03d}"]),
+                "homeDirectory": _define_value(
+                    i, "homeDirectory", [f"/home/john.smith{i:03d}"]
+                ),
                 "loginShell": _define_value(i, "loginShell", ["/bin/bash"]),
                 "mail": _define_value(i, "mail", [f"john.smith{i:03d}@mila.quebec"]),
                 "memberOf": _define_value(i, "memberOf", fake_member_of(i, nbr_users)),
-                "objectClass": _define_value(i, "objectClass", [
-                    "top",
-                    "person",
-                    "organizationalPerson",
-                    "inetOrgPerson",
-                    "posixAccount",
-                ]),
-                "physicalDeliveryOfficeName": _define_value(i, "physicalDeliveryOfficeName", []),
+                "objectClass": _define_value(
+                    i,
+                    "objectClass",
+                    [
+                        "top",
+                        "person",
+                        "organizationalPerson",
+                        "inetOrgPerson",
+                        "posixAccount",
+                    ],
+                ),
+                "physicalDeliveryOfficeName": _define_value(
+                    i, "physicalDeliveryOfficeName", []
+                ),
                 "posixUid": _define_value(i, "posixUid", [f"smithj{i:03d}"]),
                 "sn": _define_value(i, "sn", [f"Smith {i:03d}"]),
                 "suspended": _define_value(i, "suspended", ["false"]),
@@ -310,7 +363,7 @@ def fake_raw_ldap_data(nbr_users=10, hardcoded_values_by_user = {}):
                 "uid": _define_value(i, "uid", [f"john.smith{i:03d}"]),
                 "uidNumber": _define_value(i, "uidNumber", [str(1500000001 + i)]),
                 "supervisor": _define_value(i, "supervisor", None),
-                "co_supervisor": _define_value(i, "co_supervisor", None)
+                "co_supervisor": _define_value(i, "co_supervisor", None),
             }
             for i in range(nbr_users)
         ]

--- a/tests/common/sarc_mocks.py
+++ b/tests/common/sarc_mocks.py
@@ -17,14 +17,6 @@ _membership_types = [
     ],
 ]
 _affiliation_types = [
-    # Prof
-    [
-        "Collaborating Alumni",
-        "Collaborating researcher",
-        "HQP - Postdoctorate",
-        "visiting researcher",
-        "",
-    ],
     # Student
     [
         "HQP - DESS",
@@ -33,6 +25,14 @@ _affiliation_types = [
         "HQP - Professional Master's",
         "HQP - Undergraduate",
         "Research Intern",
+        "",
+    ],
+    # Prof
+    [
+        "Collaborating Alumni",
+        "Collaborating researcher",
+        "HQP - Postdoctorate",
+        "visiting researcher",
         "",
     ],
 ]

--- a/tests/common/sarc_mocks.py
+++ b/tests/common/sarc_mocks.py
@@ -201,8 +201,8 @@ def mymila_entry_builder(nbr_profs=5, hardcoded_values_by_user={}):
             mymila_template,
             {
                 "Status": _define_value(i, "Status", status[i % len(status)]),
-                "Last Name": _define_value(i, "Last Name", first_name),
-                "First Name": _define_value(i, "First Name", last_name),
+                "Last Name": _define_value(i, "Last Name", last_name),
+                "First Name": _define_value(i, "First Name", first_name),
                 "Preferred First Name": _define_value(
                     i, "Preferred First Name", first_name
                 ),

--- a/tests/common/sarc_mocks.py
+++ b/tests/common/sarc_mocks.py
@@ -310,7 +310,7 @@ def fake_raw_ldap_data(nbr_users=10, hardcoded_values_by_user = {}):
                 "uid": _define_value(i, "uid", [f"john.smith{i:03d}"]),
                 "uidNumber": _define_value(i, "uidNumber", [str(1500000001 + i)]),
                 "supervisor": _define_value(i, "supervisor", None),
-                "co_supervisor": _define_value(i, "supervisor", None)
+                "co_supervisor": _define_value(i, "co_supervisor", None)
             }
             for i in range(nbr_users)
         ]

--- a/tests/common/sarc_mocks.py
+++ b/tests/common/sarc_mocks.py
@@ -118,8 +118,8 @@ def dictset(dictionnary: dict, operation: dict):
     return result
 
 
-def fake_mymila_data(nbr_users=10, nbr_profs=5):
-    entry_ctor = mymila_entry_builder(nbr_profs)
+def fake_mymila_data(nbr_users=10, nbr_profs=5, hardcoded_values_by_user={}):
+    entry_ctor = mymila_entry_builder(nbr_profs, hardcoded_values_by_user)
 
     return pd.DataFrame(list([entry_ctor(i) for i in range(nbr_users)]))
 
@@ -128,7 +128,7 @@ def fake_mymila_data_with_history(nbr_users=10, nbr_profs=5):
     pass
 
 
-def mymila_entry_builder(nbr_profs=5):
+def mymila_entry_builder(nbr_profs=5, hardcoded_values_by_user={}):
     """
     Return a deterministically-generated list of fake MyMila users just as
     they would be returned by the function `load_mymila` (yet to be developped).
@@ -181,32 +181,48 @@ def mymila_entry_builder(nbr_profs=5):
         last_name = f"Smith{i:03d}"
         email = f"john.smith{i:03d}@mila.quebec"
 
+        def _define_value(i, key, default_value):
+            """
+            Retrieve the hardcoded value to associate to a key for a user, if any,
+            or use the default value given as parameter.
+
+            Parameters:
+                i               Index of the user in the list we want to generate
+                key             The key of the element we want to check if there is a hardcoded value for
+                default_value   The value to associate to the user and key if no hardcoded value
+                                is associated to it
+            Returns:
+                The hardcoded value defined for the user, if any.
+                The default value given as parameter otherwise.
+            """
+            return define_value(i, key, default_value, hardcoded_values_by_user)
+
         return dictset(
             mymila_template,
             {
-                "Status": status[i % len(status)],
-                "Last Name": first_name,
-                "First Name": last_name,
-                "Preferred First Name": first_name,
-                "MILA Email": email,
-                "Start Date with MILA": date(2022, 1, 1),
-                "End Date with MILA": [date(2027, 12, 31), None][i % 2],
-                "Supervisor Principal": supervisors[i % len(supervisors)],
-                "Co-Supervisor": supervisors[(i + 1) % len(supervisors)],
+                "Status": _define_value(i, "Status", status[i % len(status)]),
+                "Last Name": _define_value(i, "Last Name", first_name),
+                "First Name": _define_value(i, "First Name", last_name),
+                "Preferred First Name": _define_value(i, "Preferred First Name", first_name),
+                "MILA Email": _define_value(i, "MILA Email", email),
+                "Start Date with MILA": _define_value(i, "Start Date with MILA", date(2022, 1, 1)),
+                "End Date with MILA": _define_value(i, "End Date with MILA", [date(2027, 12, 31), None][i % 2]),
+                "Supervisor Principal": _define_value(i, "Supervisor Principal", supervisors[i % len(supervisors)]),
+                "Co-Supervisor": _define_value(i, "Co-Supervisor", supervisors[(i + 1) % len(supervisors)]),
                 # Optional
-                "Membership Type": membership_types[i % len(membership_types)],
-                "Affiliation type": affiliation_types[i % len(affiliation_types)],
-                "Faculty affiliated": faculty_affiliated[i % len(faculty_affiliated)],
-                "Program of study": program_of_study[i % len(program_of_study)],
-                "Start date of studies": date(year=2022, month=1, day=1),
-                "End date of studies": date(year=2027, month=12, day=31),
-                "Affiliated university": affiliated_university[
+                "Membership Type": _define_value(i, "Membership Type", membership_types[i % len(membership_types)]),
+                "Affiliation type": _define_value(i, "Affiliation type", affiliation_types[i % len(affiliation_types)]),
+                "Faculty affiliated": _define_value(i, "Faculty affiliated", faculty_affiliated[i % len(faculty_affiliated)]),
+                "Program of study": _define_value(i, "Program of study", program_of_study[i % len(program_of_study)]),
+                "Start date of studies": _define_value(i, "Start date of studies", date(year=2022, month=1, day=1)),
+                "End date of studies": _define_value(i, "End date of studies", date(year=2027, month=12, day=31)),
+                "Affiliated university": _define_value(i, "Affiliated university", affiliated_university[
                     i % len(affiliated_university)
-                ],
-                "Current university title": uni_title,
-                "Start date of academic nomination": date(2022, 1, 1),
-                "End date of academic nomination": [date(2027, 12, 31), None][i % 2],
-                "Email": email,
+                ]),
+                "Current university title": _define_value(i, "Current university title", uni_title),
+                "Start date of academic nomination": _define_value(i, "Start date of academic nomination", date(2022, 1, 1)),
+                "End date of academic nomination": _define_value(i, "End date of academic nomination", [date(2027, 12, 31), None][i % 2]),
+                "Email": _define_value(i, "Email", email),
             },
         )
 
@@ -227,45 +243,74 @@ def fake_member_of(index, count):
     }
     return member_of_config.get(index, [])
 
+def define_value(i, key, default_value, hardcoded_values_by_user):
+    """
+    """
 
-def fake_raw_ldap_data(nbr_users=10):
+    return hardcoded_values_by_user[i][key] if i in hardcoded_values_by_user and key in hardcoded_values_by_user[i] else default_value
+
+def fake_raw_ldap_data(nbr_users=10, hardcoded_values_by_user = {}):
     """
     Return a deterministically-generated list of fake LDAP users just as
     they would be returned by the function `query_ldap`.
     This is used for mocking the LDAP server.
+
+    Parameters:
+        nbr_users                   The number of users we want to generate
+        hardcoded_values_by_user    Dictionary associating the index of a user to
+                                    a dictionary of the values we want to hardcode
     """
+
+    def _define_value(i, key, default_value):
+        """
+        Retrieve the hardcoded value to associate to a key for a user, if any,
+        or use the default value given as parameter.
+
+        Parameters:
+            i               Index of the user in the list we want to generate
+            key             The key of the element we want to check if there is a hardcoded value for
+            default_value   The value to associate to the user and key if no hardcoded value
+                            is associated to it
+        Returns:
+            The hardcoded value defined for the user, if any.
+            The default value given as parameter otherwise.
+        """
+        return define_value(i, key, default_value, hardcoded_values_by_user)
+
     return list(
         [
             {
-                "apple-generateduid": ["AF54098F-29AE-990A-B1AC-F63F5A89B89"],
-                "cn": [f"john.smith{i:03d}", f"John Smith{i:03d}"],
-                "departmentNumber": [],
-                "displayName": [f"John Smith the {i:03d}rd"],
-                "employeeNumber": [],
-                "employeeType": [],
-                "gecos": [""],
-                "gidNumber": [str(1500000001 + i)],
-                "givenName": ["John"],
-                "googleUid": [f"john.smith{i:03d}"],
-                "homeDirectory": [f"/home/john.smith{i:03d}"],
-                "loginShell": ["/bin/bash"],
-                "mail": [f"john.smith{i:03d}@mila.quebec"],
-                "memberOf": fake_member_of(i, nbr_users),
-                "objectClass": [
+                "apple-generateduid": _define_value(i, "apple-generateduid", ["AF54098F-29AE-990A-B1AC-F63F5A89B89"]),
+                "cn": _define_value(i, "cn", [f"john.smith{i:03d}", f"John Smith{i:03d}"]),
+                "departmentNumber": _define_value(i, "departmentNumber", []),
+                "displayName": _define_value(i, "displayName", [f"John Smith the {i:03d}rd"]),
+                "employeeNumber": _define_value(i, "employeeNumber", []),
+                "employeeType": _define_value(i, "employeeType", []),
+                "gecos": _define_value(i, "gecos", [""]),
+                "gidNumber": _define_value(i, "gidNumber", [str(1500000001 + i)]),
+                "givenName": _define_value(i, "givenName", ["John"]),
+                "googleUid": _define_value(i, "googleUid", [f"john.smith{i:03d}"]),
+                "homeDirectory": _define_value(i, "homeDirectory", [f"/home/john.smith{i:03d}"]),
+                "loginShell": _define_value(i, "loginShell", ["/bin/bash"]),
+                "mail": _define_value(i, "mail", [f"john.smith{i:03d}@mila.quebec"]),
+                "memberOf": _define_value(i, "memberOf", fake_member_of(i, nbr_users)),
+                "objectClass": _define_value(i, "objectClass", [
                     "top",
                     "person",
                     "organizationalPerson",
                     "inetOrgPerson",
                     "posixAccount",
-                ],
-                "physicalDeliveryOfficeName": [],
-                "posixUid": [f"smithj{i:03d}"],
-                "sn": [f"Smith {i:03d}"],
-                "suspended": ["false"],
-                "telephoneNumber": [],
-                "title": [],
-                "uid": [f"john.smith{i:03d}"],
-                "uidNumber": [str(1500000001 + i)],
+                ]),
+                "physicalDeliveryOfficeName": _define_value(i, "physicalDeliveryOfficeName", []),
+                "posixUid": _define_value(i, "posixUid", [f"smithj{i:03d}"]),
+                "sn": _define_value(i, "sn", [f"Smith {i:03d}"]),
+                "suspended": _define_value(i, "suspended", ["false"]),
+                "telephoneNumber": _define_value(i, "telephoneNumber", []),
+                "title": _define_value(i, "title", []),
+                "uid": _define_value(i, "uid", [f"john.smith{i:03d}"]),
+                "uidNumber": _define_value(i, "uidNumber", [str(1500000001 + i)]),
+                "supervisor": _define_value(i, "supervisor", None),
+                "co_supervisor": _define_value(i, "supervisor", None)
             }
             for i in range(nbr_users)
         ]

--- a/tests/functional/cli/acquire/test_acquire_users.py
+++ b/tests/functional/cli/acquire/test_acquire_users.py
@@ -225,13 +225,13 @@ def test_acquire_users_supervisors(
         ),  # Cosupervisor only in LDAP
         (
             None,
-            "co.super.visor@mila.quebec",
-            "co.super.visor@mila.quebec",
+            "John Smith001",
+            "john.smith001@mila.quebec",
         ),  # Cosupervisor only in MyMila: this case has already been checked in the previous test
         (
             "co.super.visor.ldap@mila.quebec",
-            "co.super.visor.mymila@mila.quebec",
-            "co.super.visor.mymila@mila.quebec",
+            "John Smith001",
+            "john.smith001@mila.quebec",
         ),  # Cosupervisor in LDAP and in MyMila
     ],
 )

--- a/tests/functional/cli/acquire/test_acquire_users.py
+++ b/tests/functional/cli/acquire/test_acquire_users.py
@@ -1,5 +1,6 @@
 import io
 import json
+import random
 from io import StringIO
 from unittest.mock import MagicMock, mock_open, patch
 
@@ -9,10 +10,8 @@ import sarc.account_matching.make_matches
 import sarc.ldap.acquire
 import sarc.ldap.read_mila_ldap  # will monkeypatch "query_ldap"
 from sarc.config import config
-from tests.common.sarc_mocks import fake_raw_ldap_data, fake_mymila_data
 from sarc.ldap.api import get_user
-
-import random
+from tests.common.sarc_mocks import fake_mymila_data, fake_raw_ldap_data
 
 
 class MyStringIO(StringIO):


### PR DESCRIPTION
Add tests in order to check if the supervisor and co-supervisor are correctly retrieved from the LDAP and MyMila user data