### PR TITLE
add using_trace context manager  +  unit tests

### DIFF
--- a/sarc/traces.py
+++ b/sarc/traces.py
@@ -1,0 +1,35 @@
+from contextlib import contextmanager
+
+from opentelemetry.trace import Status, StatusCode, get_tracer
+
+
+# context manager to manage traces & span,
+# and catch exceptions (in span) without breaking the whole program execution
+@contextmanager
+def using_trace(
+    tracer_name: str, span_name: str, exception_types=[Exception]
+):  # pylint: disable=dangerous-default-value
+    """
+    Context manager to manage traces & span,
+    and catch exceptions (in span) without breaking the whole program execution.
+        Parameters:
+                tracer_name (str): name of the tracer (can be shared between different spans)
+                span_name (str): name of the span
+                exception_types ([type,..]): types of exceptions to catch, other types will be raised
+                    by default, `Exception` is caught so that nothing would be raised
+    """
+    tracer = get_tracer(tracer_name)
+    with tracer.start_as_current_span(span_name) as span:
+        try:
+            yield span
+            span.set_status(Status(StatusCode.OK))
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            span.set_status(Status(StatusCode.ERROR))
+            span.record_exception(exc)
+
+            # re-raise the exception to be caught by the caller
+            if not any(isinstance(exc, t) for t in exception_types):
+                raise
+        finally:
+            # nothing to do, end or close...
+            pass

--- a/sarc/traces.py
+++ b/sarc/traces.py
@@ -7,16 +7,23 @@ from opentelemetry.trace import Status, StatusCode, get_tracer
 # and catch exceptions (in span) without breaking the whole program execution
 @contextmanager
 def using_trace(
-    tracer_name: str, span_name: str, exception_types=[Exception]
+    tracer_name: str, span_name: str, exception_types: list = [Exception]
 ):  # pylint: disable=dangerous-default-value
     """
-    Context manager to manage traces & span,
-    and catch exceptions (in span) without breaking the whole program execution.
-        Parameters:
-                tracer_name (str): name of the tracer (can be shared between different spans)
-                span_name (str): name of the span
-                exception_types ([type,..]): types of exceptions to catch, other types will be raised
-                    by default, `Exception` is caught so that nothing would be raised
+    Context manager to manage traces & span, and catch exceptions (in span) without breaking the whole program execution.
+    Parameters
+    ----------
+    tracer_name : str
+        name of the tracer (can be shared between different spans)
+    span_name : str
+        name of the span
+    exception_types : list
+        Types of exceptions to catch, other types will be raised.
+        By default, `Exception` is caught so that nothing would be raised.
+    Yields
+    ------
+    span : opentelemetry.trace.Span
+        The span created by the context manager.
     """
     tracer = get_tracer(tracer_name)
     with tracer.start_as_current_span(span_name) as span:

--- a/sarc/traces.py
+++ b/sarc/traces.py
@@ -7,7 +7,7 @@ from opentelemetry.trace import Status, StatusCode, get_tracer
 # and catch exceptions (in span) without breaking the whole program execution
 @contextmanager
 def using_trace(
-    tracer_name: str, span_name: str, exception_types: list = [Exception]
+    tracer_name: str, span_name: str, exception_types: tuple = (Exception,)
 ):  # pylint: disable=dangerous-default-value
     """
     Context manager to manage traces & span, and catch exceptions (in span) without breaking the whole program execution.
@@ -18,7 +18,7 @@ def using_trace(
         name of the tracer (can be shared between different spans)
     span_name : str
         name of the span
-    exception_types : list
+    exception_types : tuple, optional
         Types of exceptions to catch, other types will be raised.
         By default, `Exception` is caught so that nothing would be raised.
 

--- a/sarc/traces.py
+++ b/sarc/traces.py
@@ -11,6 +11,7 @@ def using_trace(
 ):  # pylint: disable=dangerous-default-value
     """
     Context manager to manage traces & span, and catch exceptions (in span) without breaking the whole program execution.
+
     Parameters
     ----------
     tracer_name : str

--- a/sarc/traces.py
+++ b/sarc/traces.py
@@ -20,6 +20,7 @@ def using_trace(
     exception_types : list
         Types of exceptions to catch, other types will be raised.
         By default, `Exception` is caught so that nothing would be raised.
+
     Yields
     ------
     span : opentelemetry.trace.Span

--- a/tests/unittests/test_using_trace.py
+++ b/tests/unittests/test_using_trace.py
@@ -1,5 +1,6 @@
 # test the traces helper context manager
 
+import pytest
 from opentelemetry.trace import Status, StatusCode, get_tracer
 
 from sarc.traces import using_trace
@@ -64,7 +65,7 @@ def test_using_trace_expected_exception(captrace):
 
 def test_using_trace_unexpected_exception(captrace):
     exception_caught = False
-    try:
+    with pytest.raises(AssertionError):
         with using_trace("test_using_trace_noerror", "span1") as span:
             pass
         with using_trace(
@@ -74,12 +75,7 @@ def test_using_trace_unexpected_exception(captrace):
         ) as span:
             span.add_event("event1")
             assert False
-    except Exception:
-        exception_caught = True
 
-    assert (
-        exception_caught == True
-    )  # the ExceptionError is not handled by the context manager
     traces = captrace.get_finished_spans()
     assert len(traces) == 2
     assert traces[0].status.status_code == StatusCode.OK

--- a/tests/unittests/test_using_trace.py
+++ b/tests/unittests/test_using_trace.py
@@ -46,7 +46,7 @@ def test_using_trace_expected_exception(captrace):
     with using_trace(
         "test_using_trace_default_exception",
         "span2",
-        exception_types=[ZeroDivisionError],
+        exception_types=(ZeroDivisionError,),
     ) as span:
         span.add_event("event1")
         a = 1 / 0

--- a/tests/unittests/test_using_trace.py
+++ b/tests/unittests/test_using_trace.py
@@ -37,6 +37,7 @@ def test_using_trace_default_exception(captrace):
     assert len(spans) == 2
     assert spans[0].status.status_code == StatusCode.OK
     assert spans[1].status.status_code == StatusCode.ERROR
+    assert any(e.name == "exception" for e in spans[1].events)
 
 
 def test_using_trace_expected_exception(captrace):
@@ -55,6 +56,7 @@ def test_using_trace_expected_exception(captrace):
     assert len(spans) == 2
     assert spans[0].status.status_code == StatusCode.OK
     assert spans[1].status.status_code == StatusCode.ERROR
+    assert any(e.name == "exception" for e in spans[1].events)
 
 
 def test_using_trace_unexpected_exception(captrace):
@@ -95,11 +97,14 @@ def test_using_trace_noerror_nested_1_tracer(captrace):
     )  # spans are in their order of ending, so span2 is first
     assert len(spans[0].events) == 1
     assert spans[0].events[0].name == "event2"
+    assert spans[0].parent is not None
+    assert spans[0].parent == spans[1].get_span_context()
 
     assert spans[1].name == "span1"
     assert len(spans[1].events) == 2
     assert "event1.1" in [e.name for e in spans[1].events]
     assert "event1.2" in [e.name for e in spans[1].events]
+    assert spans[1].parent is None
 
 
 def test_using_trace_noerror_nested_2_tracers(captrace):
@@ -120,11 +125,14 @@ def test_using_trace_noerror_nested_2_tracers(captrace):
     )  # spans are in their order of ending, so span2 is first
     assert len(spans[0].events) == 1
     assert spans[0].events[0].name == "event2"
+    assert spans[0].parent is not None
+    assert spans[0].parent == spans[1].get_span_context()
 
     assert spans[1].name == "span1"
     assert len(spans[1].events) == 2
     assert "event1.1" in [e.name for e in spans[1].events]
     assert "event1.2" in [e.name for e in spans[1].events]
+    assert spans[1].parent is None
 
 
 def test_using_trace_error_nested(captrace):

--- a/tests/unittests/test_using_trace.py
+++ b/tests/unittests/test_using_trace.py
@@ -1,4 +1,4 @@
-# test the traces helper context manager
+# test the spans helper context manager
 
 import pytest
 from opentelemetry.trace import Status, StatusCode, get_tracer
@@ -13,18 +13,18 @@ def test_using_trace_noerror(captrace):
         span.add_event("event2.1")
         span.add_event("event2.2")
 
-    # check traces
-    traces = captrace.get_finished_spans()
-    assert len(traces) == 2
-    assert traces[0].name == "span1"
-    assert len(traces[0].events) == 1
-    assert "event1" in [e.name for e in traces[0].events]
-    assert traces[0].status.status_code == StatusCode.OK
-    assert traces[1].name == "span2"
-    assert len(traces[1].events) == 2
-    assert "event2.1" in [e.name for e in traces[1].events]
-    assert "event2.2" in [e.name for e in traces[1].events]
-    assert traces[1].status.status_code == StatusCode.OK
+    # check spans
+    spans = captrace.get_finished_spans()
+    assert len(spans) == 2
+    assert spans[0].name == "span1"
+    assert len(spans[0].events) == 1
+    assert "event1" in [e.name for e in spans[0].events]
+    assert spans[0].status.status_code == StatusCode.OK
+    assert spans[1].name == "span2"
+    assert len(spans[1].events) == 2
+    assert "event2.1" in [e.name for e in spans[1].events]
+    assert "event2.2" in [e.name for e in spans[1].events]
+    assert spans[1].status.status_code == StatusCode.OK
 
 
 def test_using_trace_default_exception(captrace):
@@ -33,10 +33,10 @@ def test_using_trace_default_exception(captrace):
     with using_trace("test_using_trace_default_exception", "span2") as span:
         span.add_event("event1")
         raise Exception("test exception")
-    traces = captrace.get_finished_spans()
-    assert len(traces) == 2
-    assert traces[0].status.status_code == StatusCode.OK
-    assert traces[1].status.status_code == StatusCode.ERROR
+    spans = captrace.get_finished_spans()
+    assert len(spans) == 2
+    assert spans[0].status.status_code == StatusCode.OK
+    assert spans[1].status.status_code == StatusCode.ERROR
 
 
 def test_using_trace_expected_exception(captrace):
@@ -51,10 +51,10 @@ def test_using_trace_expected_exception(captrace):
         span.add_event("event1")
         a = 1 / 0
 
-    traces = captrace.get_finished_spans()
-    assert len(traces) == 2
-    assert traces[0].status.status_code == StatusCode.OK
-    assert traces[1].status.status_code == StatusCode.ERROR
+    spans = captrace.get_finished_spans()
+    assert len(spans) == 2
+    assert spans[0].status.status_code == StatusCode.OK
+    assert spans[1].status.status_code == StatusCode.ERROR
 
 
 def test_using_trace_unexpected_exception(captrace):
@@ -70,10 +70,10 @@ def test_using_trace_unexpected_exception(captrace):
             span.add_event("event1")
             assert False
 
-    traces = captrace.get_finished_spans()
-    assert len(traces) == 2
-    assert traces[0].status.status_code == StatusCode.OK
-    assert traces[1].status.status_code == StatusCode.ERROR
+    spans = captrace.get_finished_spans()
+    assert len(spans) == 2
+    assert spans[0].status.status_code == StatusCode.OK
+    assert spans[1].status.status_code == StatusCode.ERROR
 
 
 def test_using_trace_noerror_nested_1_tracer(captrace):
@@ -84,21 +84,21 @@ def test_using_trace_noerror_nested_1_tracer(captrace):
             span2.add_event("event2")
         span.add_event("event1.2")
 
-    # check traces
-    traces = captrace.get_finished_spans()
-    print(f"traces: {traces}")
-    assert len(traces) == 2
+    # check spans
+    spans = captrace.get_finished_spans()
+    print(f"spans: {spans}")
+    assert len(spans) == 2
 
     assert (
-        traces[0].name == "span2"
+        spans[0].name == "span2"
     )  # spans are in their order of ending, so span2 is first
-    assert len(traces[0].events) == 1
-    assert traces[0].events[0].name == "event2"
+    assert len(spans[0].events) == 1
+    assert spans[0].events[0].name == "event2"
 
-    assert traces[1].name == "span1"
-    assert len(traces[1].events) == 2
-    assert "event1.1" in [e.name for e in traces[1].events]
-    assert "event1.2" in [e.name for e in traces[1].events]
+    assert spans[1].name == "span1"
+    assert len(spans[1].events) == 2
+    assert "event1.1" in [e.name for e in spans[1].events]
+    assert "event1.2" in [e.name for e in spans[1].events]
 
 
 def test_using_trace_noerror_nested_2_tracers(captrace):
@@ -109,21 +109,21 @@ def test_using_trace_noerror_nested_2_tracers(captrace):
             span2.add_event("event2")
         span.add_event("event1.2")
 
-    # check traces
-    traces = captrace.get_finished_spans()
-    print(f"traces: {traces}")
-    assert len(traces) == 2
+    # check spans
+    spans = captrace.get_finished_spans()
+    print(f"spans: {spans}")
+    assert len(spans) == 2
 
     assert (
-        traces[0].name == "span2"
+        spans[0].name == "span2"
     )  # spans are in their order of ending, so span2 is first
-    assert len(traces[0].events) == 1
-    assert traces[0].events[0].name == "event2"
+    assert len(spans[0].events) == 1
+    assert spans[0].events[0].name == "event2"
 
-    assert traces[1].name == "span1"
-    assert len(traces[1].events) == 2
-    assert "event1.1" in [e.name for e in traces[1].events]
-    assert "event1.2" in [e.name for e in traces[1].events]
+    assert spans[1].name == "span1"
+    assert len(spans[1].events) == 2
+    assert "event1.1" in [e.name for e in spans[1].events]
+    assert "event1.2" in [e.name for e in spans[1].events]
 
 
 def test_using_trace_error_nested(captrace):
@@ -139,21 +139,21 @@ def test_using_trace_error_nested(captrace):
             a = 1 / 0
         span.add_event("event1.2")
 
-    # check traces
-    traces = captrace.get_finished_spans()
-    print(f"traces: {traces}")
-    assert len(traces) == 2
+    # check spans
+    spans = captrace.get_finished_spans()
+    print(f"spans: {spans}")
+    assert len(spans) == 2
 
     assert (
-        traces[0].name == "span2"
+        spans[0].name == "span2"
     )  # spans are in their order of ending, so span2 is first
-    assert len(traces[0].events) == 2
-    assert traces[0].events[0].name == "event2"
-    assert traces[0].events[1].name == "exception"
-    assert traces[0].status.status_code == StatusCode.ERROR
+    assert len(spans[0].events) == 2
+    assert spans[0].events[0].name == "event2"
+    assert spans[0].events[1].name == "exception"
+    assert spans[0].status.status_code == StatusCode.ERROR
 
-    assert traces[1].name == "span1"
-    assert len(traces[1].events) == 2
-    assert "event1.1" in [e.name for e in traces[1].events]
-    assert "event1.2" in [e.name for e in traces[1].events]
-    assert traces[1].status.status_code == StatusCode.OK
+    assert spans[1].name == "span1"
+    assert len(spans[1].events) == 2
+    assert "event1.1" in [e.name for e in spans[1].events]
+    assert "event1.2" in [e.name for e in spans[1].events]
+    assert spans[1].status.status_code == StatusCode.OK

--- a/tests/unittests/test_using_trace.py
+++ b/tests/unittests/test_using_trace.py
@@ -80,3 +80,49 @@ def test_using_trace_unexpected_exception(captrace):
     assert len(traces) == 2
     assert traces[0].status.status_code == StatusCode.OK
     assert traces[1].status.status_code == StatusCode.ERROR
+
+
+def test_using_trace_noerror_nested_1_tracer(captrace):
+    # test nested spans in the same tracer
+    with using_trace("test_using_trace_nested_spans", "span1") as span:
+        span.add_event("event1.1")
+        with using_trace("test_using_trace_nested_spans", "span2") as span2:
+            span2.add_event("event2")
+        span.add_event("event1.2")
+
+    # check traces
+    traces = captrace.get_finished_spans()
+    print(f"traces: {traces}")
+    assert len(traces) == 2
+
+    assert traces[0].name == "span2"
+    assert len(traces[0].events) == 1
+    assert traces[0].events[0].name == "event2"
+
+    assert traces[1].name == "span1"
+    assert len(traces[1].events) == 2
+    assert "event1.1" in [e.name for e in traces[1].events]
+    assert "event1.2" in [e.name for e in traces[1].events]
+
+
+def test_using_trace_noerror_nested_2_tracers(captrace):
+    # test netsed spans in different tracers
+    with using_trace("test_using_trace_nested_trace_1", "span1") as span:
+        span.add_event("event1.1")
+        with using_trace("test_using_trace_nested_trace_2", "span2") as span2:
+            span2.add_event("event2")
+        span.add_event("event1.2")
+
+    # check traces
+    traces = captrace.get_finished_spans()
+    print(f"traces: {traces}")
+    assert len(traces) == 2
+
+    assert traces[0].name == "span2"
+    assert len(traces[0].events) == 1
+    assert traces[0].events[0].name == "event2"
+
+    assert traces[1].name == "span1"
+    assert len(traces[1].events) == 2
+    assert "event1.1" in [e.name for e in traces[1].events]
+    assert "event1.2" in [e.name for e in traces[1].events]

--- a/tests/unittests/test_using_trace.py
+++ b/tests/unittests/test_using_trace.py
@@ -41,22 +41,16 @@ def test_using_trace_default_exception(captrace):
 
 def test_using_trace_expected_exception(captrace):
     exception_caught = False
-    try:
-        with using_trace("test_using_trace_noerror", "span1") as span:
-            pass
-        with using_trace(
-            "test_using_trace_default_exception",
-            "span2",
-            exception_types=[ZeroDivisionError],
-        ) as span:
-            span.add_event("event1")
-            a = 1 / 0
-    except Exception:
-        exception_caught = True
+    with using_trace("test_using_trace_noerror", "span1") as span:
+        pass
+    with using_trace(
+        "test_using_trace_default_exception",
+        "span2",
+        exception_types=[ZeroDivisionError],
+    ) as span:
+        span.add_event("event1")
+        a = 1 / 0
 
-    assert (
-        exception_caught == False
-    )  # the exception should be handled by the context manager
     traces = captrace.get_finished_spans()
     assert len(traces) == 2
     assert traces[0].status.status_code == StatusCode.OK
@@ -95,7 +89,9 @@ def test_using_trace_noerror_nested_1_tracer(captrace):
     print(f"traces: {traces}")
     assert len(traces) == 2
 
-    assert traces[0].name == "span2"
+    assert (
+        traces[0].name == "span2"
+    )  # spans are in their order of ending, so span2 is first
     assert len(traces[0].events) == 1
     assert traces[0].events[0].name == "event2"
 
@@ -118,7 +114,9 @@ def test_using_trace_noerror_nested_2_tracers(captrace):
     print(f"traces: {traces}")
     assert len(traces) == 2
 
-    assert traces[0].name == "span2"
+    assert (
+        traces[0].name == "span2"
+    )  # spans are in their order of ending, so span2 is first
     assert len(traces[0].events) == 1
     assert traces[0].events[0].name == "event2"
 
@@ -126,3 +124,36 @@ def test_using_trace_noerror_nested_2_tracers(captrace):
     assert len(traces[1].events) == 2
     assert "event1.1" in [e.name for e in traces[1].events]
     assert "event1.2" in [e.name for e in traces[1].events]
+
+
+def test_using_trace_error_nested(captrace):
+    # test nested spans in the same tracer
+    with using_trace("test_using_trace_nested_spans", "span1") as span:
+        span.add_event("event1.1")
+        with using_trace(
+            "test_using_trace_nested_spans",
+            "span2",
+            exception_types=[ZeroDivisionError],
+        ) as span2:
+            span2.add_event("event2")
+            a = 1 / 0
+        span.add_event("event1.2")
+
+    # check traces
+    traces = captrace.get_finished_spans()
+    print(f"traces: {traces}")
+    assert len(traces) == 2
+
+    assert (
+        traces[0].name == "span2"
+    )  # spans are in their order of ending, so span2 is first
+    assert len(traces[0].events) == 2
+    assert traces[0].events[0].name == "event2"
+    assert traces[0].events[1].name == "exception"
+    assert traces[0].status.status_code == StatusCode.ERROR
+
+    assert traces[1].name == "span1"
+    assert len(traces[1].events) == 2
+    assert "event1.1" in [e.name for e in traces[1].events]
+    assert "event1.2" in [e.name for e in traces[1].events]
+    assert traces[1].status.status_code == StatusCode.OK

--- a/tests/unittests/test_using_trace.py
+++ b/tests/unittests/test_using_trace.py
@@ -1,0 +1,86 @@
+# test the traces helper context manager
+
+from opentelemetry.trace import Status, StatusCode, get_tracer
+
+from sarc.traces import using_trace
+
+
+def test_using_trace_noerror(captrace):
+    with using_trace("test_using_trace_noerror", "span1") as span:
+        span.add_event("event1")
+    with using_trace("test_using_trace_noerror", "span2") as span:
+        span.add_event("event2.1")
+        span.add_event("event2.2")
+
+    # check traces
+    traces = captrace.get_finished_spans()
+    assert len(traces) == 2
+    assert traces[0].name == "span1"
+    assert len(traces[0].events) == 1
+    assert "event1" in [e.name for e in traces[0].events]
+    assert traces[0].status.status_code == StatusCode.OK
+    assert traces[1].name == "span2"
+    assert len(traces[1].events) == 2
+    assert "event2.1" in [e.name for e in traces[1].events]
+    assert "event2.2" in [e.name for e in traces[1].events]
+    assert traces[1].status.status_code == StatusCode.OK
+
+
+def test_using_trace_default_exception(captrace):
+    with using_trace("test_using_trace_noerror", "span1") as span:
+        pass
+    with using_trace("test_using_trace_default_exception", "span2") as span:
+        span.add_event("event1")
+        raise Exception("test exception")
+    traces = captrace.get_finished_spans()
+    assert len(traces) == 2
+    assert traces[0].status.status_code == StatusCode.OK
+    assert traces[1].status.status_code == StatusCode.ERROR
+
+
+def test_using_trace_expected_exception(captrace):
+    exception_caught = False
+    try:
+        with using_trace("test_using_trace_noerror", "span1") as span:
+            pass
+        with using_trace(
+            "test_using_trace_default_exception",
+            "span2",
+            exception_types=[ZeroDivisionError],
+        ) as span:
+            span.add_event("event1")
+            a = 1 / 0
+    except Exception:
+        exception_caught = True
+
+    assert (
+        exception_caught == False
+    )  # the exception should be handled by the context manager
+    traces = captrace.get_finished_spans()
+    assert len(traces) == 2
+    assert traces[0].status.status_code == StatusCode.OK
+    assert traces[1].status.status_code == StatusCode.ERROR
+
+
+def test_using_trace_unexpected_exception(captrace):
+    exception_caught = False
+    try:
+        with using_trace("test_using_trace_noerror", "span1") as span:
+            pass
+        with using_trace(
+            "test_using_trace_default_exception",
+            "span2",
+            exception_types=[ZeroDivisionError],
+        ) as span:
+            span.add_event("event1")
+            assert False
+    except Exception:
+        exception_caught = True
+
+    assert (
+        exception_caught == True
+    )  # the ExceptionError is not handled by the context manager
+    traces = captrace.get_finished_spans()
+    assert len(traces) == 2
+    assert traces[0].status.status_code == StatusCode.OK
+    assert traces[1].status.status_code == StatusCode.ERROR

--- a/tests/unittests/test_using_trace.py
+++ b/tests/unittests/test_using_trace.py
@@ -74,6 +74,7 @@ def test_using_trace_unexpected_exception(captrace):
     assert len(spans) == 2
     assert spans[0].status.status_code == StatusCode.OK
     assert spans[1].status.status_code == StatusCode.ERROR
+    assert any(e.name == "exception" for e in spans[1].events)
 
 
 def test_using_trace_noerror_nested_1_tracer(captrace):


### PR DESCRIPTION
add `using_trace` context manager for automatic traces handling:
- exceptions are added to span automatically
- status is set to OK if no exception occur

tests can be used as examples of use