### PR TITLE
[SARC-312] Update @satyaog code from PR #115 to harmonize GPU names

### DIFF
--- a/config/sarc-dev.json
+++ b/config/sarc-dev.json
@@ -28,7 +28,42 @@
             "duc_storage_command": null,
             "diskusage_report_command": "beegfs-ctl --cfgFile=/etc/beegfs/home.d/beegfs-client.conf --getquota --uid $USER --csv",
             "prometheus_url": "http://prometheus01.server.mila.quebec:9090/",
-            "start_date": "2022-04-01"
+            "start_date": "2022-04-01",
+            "gpus_per_nodes": {
+                "__DEFAULTS__": {
+                    "rtx8000": "RTX8000"
+                },
+                "cn-b[001-005]": {
+                    "v100": "V100-SXM2-32GB"
+                },
+                "cn-d[001-002]": {
+                    "a100": "A100-SXM4-40GB"
+                },
+                "cn-d[003-004]": {
+                    "a100l": "A100-SXM4-80GB"
+                },
+                "cn-e[002-003]": {
+                    "v100": "V100-SXM2-32GB"
+                },
+                "cn-g[001-029]": {
+                    "a100l": "A100-SXM4-80GB"
+                },
+                "cn-i001": {
+                    "a100l": "A100-PCIe-80GB"
+                },
+                "cn-j001": {
+                    "a6000": "A6000"
+                },
+                "cn-k[001-004]": {
+                    "a100": "A100-SXM4-40GB"
+                },
+                "cn-l[001-091]": {
+                    "l40s": "L40S"
+                },
+                "cn-n[001-002]": {
+                    "h100": "H100-SXM5-80GB"
+                }
+            }
         },
         "narval": {
             "host": "narval.computecanada.ca",
@@ -42,7 +77,16 @@
             "prometheus_headers_file": "secrets/drac_prometheus/headers.json",
             "start_date": "2022-04-01",
             "rgu_start_date": "2023-11-28",
-            "gpu_to_rgu_billing": "secrets/gpu_to_rgu_billing_narval.json"
+            "gpu_to_rgu_billing": "secrets/gpu_to_rgu_billing_narval.json",
+            "gpus_per_nodes": {
+                "__DEFAULTS__": {
+                    "a100": "A100-SXM4-40GB",
+                    "a100_1g.5gb": "__MIG_FLAG__a100",
+                    "a100_2g.10gb": "__MIG_FLAG__a100",
+                    "a100_3g.20gb": "__MIG_FLAG__a100",
+                    "a100_4g.20gb": "__MIG_FLAG__a100"
+                }
+            }
         },
         "beluga": {
             "host": "beluga.computecanada.ca",
@@ -56,7 +100,12 @@
             "prometheus_headers_file": "secrets/drac_prometheus/headers.json",
             "start_date": "2022-04-01",
             "rgu_start_date": "2024-04-03",
-            "gpu_to_rgu_billing": "secrets/gpu_to_rgu_billing_beluga.json"
+            "gpu_to_rgu_billing": "secrets/gpu_to_rgu_billing_beluga.json",
+            "gpus_per_nodes": {
+                "__DEFAULTS__": {
+                    "tesla_v100-sxm2-16gb": "V100-SXM2-16GB"
+                }
+            }
         },
         "graham": {
             "host": "graham.computecanada.ca",
@@ -70,7 +119,30 @@
             "prometheus_headers_file": null,
             "start_date": "2022-04-01",
             "rgu_start_date": "2024-04-03",
-            "gpu_to_rgu_billing": "secrets/gpu_to_rgu_billing_graham.json"
+            "gpu_to_rgu_billing": "secrets/gpu_to_rgu_billing_graham.json",
+            "gpus_per_nodes": {
+                "gra[828-987]": {
+                    "p100": "P100-PCIe-12GB"
+                },
+                "gra[1147-1153]": {
+                    "v100": "V100-PCIe-16GB"
+                },
+                "gra[1154-1189]": {
+                    "t4": "T4"
+                },
+                "gra[1337-1338]": {
+                    "v100": "V100-SXM2-32GB"
+                },
+                "gra1342": {
+                    "a100": "A100-SXM4-80GB"
+                },
+                "gra[1361-1362]": {
+                    "a100": "A100-PCIe-80GB"
+                },
+                "gra[1363-1373]": {
+                    "a5000": "A5000"
+                }
+            }
         },
         "cedar": {
             "host": "cedar.computecanada.ca",
@@ -84,7 +156,14 @@
             "prometheus_headers_file": null,
             "start_date": "2022-04-01",
             "rgu_start_date": "2024-04-03",
-            "gpu_to_rgu_billing": "secrets/gpu_to_rgu_billing_cedar.json"
+            "gpu_to_rgu_billing": "secrets/gpu_to_rgu_billing_cedar.json",
+            "gpus_per_nodes": {
+                "__DEFAULTS__": {
+                    "p100": "P100-PCIe-12GB",
+                    "p100l": "P100-PCIe-16GB",
+                    "v100l": "V100-PCIe-32GB"
+                }
+            }
         }
     }
 }

--- a/config/sarc-dev.json
+++ b/config/sarc-dev.json
@@ -31,7 +31,16 @@
             "start_date": "2022-04-01",
             "gpus_per_nodes": {
                 "__DEFAULTS__": {
-                    "rtx8000": "RTX8000"
+                    "rtx8000": "RTX8000",
+                    "NVIDIA A100 80GB PCIe": "A100-PCIe-80GB",
+                    "NVIDIA A100-SXM4-40GB": "A100-SXM4-40GB",
+                    "NVIDIA A100-SXM4-80GB": "A100-SXM4-80GB",
+                    "NVIDIA H100 80GB HBM3": "H100-SXM5-80GB",
+                    "NVIDIA L40S": "L40S",
+                    "NVIDIA RTX A6000": "A6000",
+                    "Quadro RTX 8000": "RTX8000",
+                    "Tesla V100-SXM2-32GB": "V100-SXM2-32GB",
+                    "Tesla V100-SXM2-32GB-LS": "V100-SXM2-32GB"
                 },
                 "cn-b[001-005]": {
                     "v100": "V100-SXM2-32GB"
@@ -46,7 +55,10 @@
                     "v100": "V100-SXM2-32GB"
                 },
                 "cn-g[001-029]": {
-                    "a100l": "A100-SXM4-80GB"
+                    "a100l": "A100-SXM4-80GB",
+                    "2g.20gb": "__MIG_FLAG__a100l",
+                    "3g.40gb": "__MIG_FLAG__a100l",
+                    "4g.40gb": "__MIG_FLAG__a100l"
                 },
                 "cn-i001": {
                     "a100l": "A100-PCIe-80GB"
@@ -83,8 +95,12 @@
                     "a100": "A100-SXM4-40GB",
                     "a100_1g.5gb": "__MIG_FLAG__a100",
                     "a100_2g.10gb": "__MIG_FLAG__a100",
+                    "2g.10gb": "__MIG_FLAG__a100",
                     "a100_3g.20gb": "__MIG_FLAG__a100",
-                    "a100_4g.20gb": "__MIG_FLAG__a100"
+                    "3g.20gb": "__MIG_FLAG__a100",
+                    "a100_4g.20gb": "__MIG_FLAG__a100",
+                    "4g.20gb": "__MIG_FLAG__a100",
+                    "NVIDIA A100-SXM4-40GB": "A100-SXM4-40GB"
                 }
             }
         },
@@ -103,7 +119,8 @@
             "gpu_to_rgu_billing": "secrets/gpu_to_rgu_billing_beluga.json",
             "gpus_per_nodes": {
                 "__DEFAULTS__": {
-                    "tesla_v100-sxm2-16gb": "V100-SXM2-16GB"
+                    "tesla_v100-sxm2-16gb": "V100-SXM2-16GB",
+                    "Tesla V100-SXM2-16GB": "V100-SXM2-16GB"
                 }
             }
         },

--- a/sarc/config.py
+++ b/sarc/config.py
@@ -7,7 +7,7 @@ from contextvars import ContextVar
 from datetime import date, datetime
 from functools import cached_property
 from pathlib import Path
-from typing import Any, Dict, Union
+from typing import Any, Dict, Optional, Union
 
 import pydantic
 import tzlocal
@@ -111,8 +111,12 @@ class ClusterConfig(BaseModel):
             for node in expand_hostlist(node_list)
         }
 
-    def harmonize_gpu(self, nodename: str, gpu_type: str) -> str:
-        """Actual utility method to get a GPU name from given node and gpu type."""
+    def harmonize_gpu(self, nodename: str, gpu_type: str) -> Optional[str]:
+        """
+        Actual utility method to get a GPU name from given node and gpu type.
+
+        Return None if GPU name cannot be inferred.
+        """
 
         gpu_type = gpu_type.lower().replace(" ", "-").split(":")
         if gpu_type[0] == "gpu":

--- a/sarc/users/revision.py
+++ b/sarc/users/revision.py
@@ -9,7 +9,7 @@ The revison works as follow:
 - All current documents have NO end date
     - this makes query simple as we can just look for missing end date,
       because previous db had no revision system none of the documents have
-      end dates, so all their documents are the current ones 
+      end dates, so all their documents are the current ones
 
 - All past version have an end date
 """

--- a/tests/functional/jobs/test_func_sacct.py
+++ b/tests/functional/jobs/test_func_sacct.py
@@ -472,7 +472,7 @@ def test_get_gpu_type_without_prometheus(
     job = jobs[0]
     print(job)
     print(job.nodes)
-    assert job.allocated.gpu_type == "gpu:asupergpu:4"
+    assert job.allocated.gpu_type == "Nec Plus ULTRA GPU 2000"
 
     file_regression.check(
         f"Found {len(jobs)} job(s):\n"

--- a/tests/functional/jobs/test_func_sacct/test_get_gpu_type_without_prometheus_json_jobs0_test_config0_.txt
+++ b/tests/functional/jobs/test_func_sacct/test_get_gpu_type_without_prometheus_json_jobs0_test_config0_.txt
@@ -42,7 +42,7 @@ Found 1 job(s):
         "node": 1,
         "billing": 1,
         "gres_gpu": 1,
-        "gpu_type": "gpu:asupergpu:4"
+        "gpu_type": "Nec Plus ULTRA GPU 2000"
     },
     "stored_statistics": null
 }

--- a/tests/sarc-test.json
+++ b/tests/sarc-test.json
@@ -41,7 +41,15 @@
             "duc_inodes_command": null,
             "duc_storage_command": null,
             "diskusage_report_command": null,
-            "prometheus_url": null
+            "prometheus_url": null,
+            "gpus_per_nodes" : {
+                "cn-c018": {
+                    "asupergpu": "Nec Plus Plus ULTRA GPU 2000"
+                },
+                "cn-c[019-030]": {
+                    "asupergpu": "Nec Plus ULTRA GPU 2000"
+                }
+            }
         },
         "fromage": {
             "host": "fromage",

--- a/tests/unittests/jobs/test_harmonize_gpu.py
+++ b/tests/unittests/jobs/test_harmonize_gpu.py
@@ -1,0 +1,70 @@
+import pytest
+
+from sarc.config import DEFAULTS_FLAG, MIG_FLAG, ClusterConfig, config
+
+GPUS_PER_NODES = {
+    "node[0-9]": {"gpu1": "DESCRIPTIVE GPU 1"},
+    "node[9-19]": {"gpu2": "DESCRIPTIVE GPU 2"},
+    "node_mig20": {"gpu3": "DESCRIPTIVE GPU 3", "4g.40gb": f"{MIG_FLAG}gpu3"},
+    DEFAULTS_FLAG: {"gpu_default": "DESCRIPTIVE GPU DEFAULT"},
+}
+
+
+@pytest.mark.parametrize(
+    "node,gpu_type,expected,gpus_per_nodes",
+    [
+        [
+            "DoesNotExist",
+            "DoesNotExist",
+            None,
+            {},
+        ],
+        [
+            "node1",
+            "GPU1",
+            "DESCRIPTIVE GPU 1",
+            GPUS_PER_NODES,
+        ],
+        [
+            "node11",
+            "GPU2",
+            "DESCRIPTIVE GPU 2",
+            GPUS_PER_NODES,
+        ],
+        [
+            "DoesNotExist",
+            "GPU_DEFAULT",
+            "DESCRIPTIVE GPU DEFAULT",
+            GPUS_PER_NODES,
+        ],
+        [
+            "node1",
+            "DoesNotExist",
+            None,
+            GPUS_PER_NODES,
+        ],
+        [
+            "node_mig20",
+            "4g.40gb",
+            "DESCRIPTIVE GPU 3 : 4g.40gb",
+            GPUS_PER_NODES,
+        ],
+    ],
+)
+def test_harmonize_gpu(node, gpu_type, expected, gpus_per_nodes):
+    cluster = ClusterConfig(timezone="America/Montreal", gpus_per_nodes=gpus_per_nodes)
+    assert cluster.harmonize_gpu(node, gpu_type) == expected
+
+
+@pytest.mark.usefixtures("standard_config")
+@pytest.mark.parametrize(
+    "node,gpu_type,expected",
+    [
+        ("cn-c018", "asupergpu", "Nec Plus Plus ULTRA GPU 2000"),
+        ("cn-c019", "asupergpu", "Nec Plus ULTRA GPU 2000"),
+        ("cn-c024", "asupergpu", "Nec Plus ULTRA GPU 2000"),
+    ],
+)
+def test_clusterconfig_harmonize_gpu(node, gpu_type, expected):
+    cluster = config().clusters["raisin_no_prometheus"]
+    assert cluster.harmonize_gpu(node, gpu_type) == expected

--- a/tox.ini
+++ b/tox.ini
@@ -6,13 +6,13 @@ envlist = py310
 
 [testenv:test]
 description = run tests
-deps = 
+deps =
     poetry
 allowlist_externals =
     podman
-commands_pre = 
+commands_pre =
     podman run -dt --name testenv_mongo -p 27017:27017/tcp docker.io/library/mongo:latest
-commands = 
+commands =
     poetry install --with dev
     poetry run coverage run --source sarc --parallel-mode -m pytest --doctest-modules --durations=50 --durations-min 1 -vv --timeout=20 -vvv tests/ {posargs}
     poetry run coverage combine
@@ -25,19 +25,19 @@ commands_post =
 description = run linters
 deps =
     pylint
-commands = 
+commands =
     pylint sarc
 
 [testenv:black]
 description = run linters
 deps =
     black
-commands = 
+commands =
     black --check .
 
 [testenv:isort]
 description = run linters
 deps =
     isort
-commands = 
+commands =
     isort -c --df --profile black .


### PR DESCRIPTION
Cette PR s'inspire de la PR #115 pour convertir les `gpu_type` des nodes en noms plus descriptifs.

Les noms descriptifs des GPUs sont censés être les mêmes que ceux utilisés dans le package IGUANE: https://github.com/mila-iqia/IGUANE/blob/master/iguane/rawdata.toml

La PR actuelle se content d'ajouter une méthode `ClusterConfig.harmonize_gpu(nodename, gpu_type) -> str` qui retourne le nom descriptif pour un nodename (e.g. `cdr1234`) et un gpu_type (e.g. `a100`) donnés. J'ai préféré ne pas modifier les jobs pour le moment (`job.alllocated.gpu_type` retourne toujours les gpu_types tels qu'on les connait actuellement).
