### PR TITLE
move `secrets`folder outside project folders structure

### DIFF
--- a/config/sarc-dev.json
+++ b/config/sarc-dev.json
@@ -9,17 +9,17 @@
         "database_name": "sarc-dev"
     },
     "ldap": {
-        "local_private_key_file": "secrets/ldap/Google_2026_01_26_66827.key",
-        "local_certificate_file": "secrets/ldap/Google_2026_01_26_66827.crt",
+        "local_private_key_file": "../SARC_secrets/secrets/ldap/Google_2026_01_26_66827.key",
+        "local_certificate_file": "../SARC_secrets/secrets/ldap/Google_2026_01_26_66827.crt",
         "ldap_service_uri": "ldaps://ldap.google.com",
         "mongo_collection_name": "users",
-        "group_to_prof_json_path": "secrets/group_to_prof.json",
-        "exceptions_json_path": "secrets/exceptions.json"
+        "group_to_prof_json_path": "../SARC_secrets/secrets/group_to_prof.json",
+        "exceptions_json_path": "../SARC_secrets/secrets/exceptions.json"
     },
     "account_matching": {
-        "drac_members_csv_path": "secrets/account_matching/members-rrg-bengioy-ad-2022-11-25.csv",
-        "drac_roles_csv_path": "secrets/account_matching/sponsored_roles_for_Yoshua_Bengio_(CCI_jvb-000).csv",
-        "make_matches_config": "secrets/account_matching/make_matches_config.json"
+        "drac_members_csv_path": "../SARC_secrets/secrets/account_matching/members-rrg-bengioy-ad-2022-11-25.csv",
+        "drac_roles_csv_path": "../SARC_secrets/secrets/account_matching/sponsored_roles_for_Yoshua_Bengio_(CCI_jvb-000).csv",
+        "make_matches_config": "../SARC_secrets/secrets/account_matching/make_matches_config.json"
     },
     "cache": "./sarc-cache",
     "sshconfig": "~/.ssh/config",
@@ -92,10 +92,10 @@
             "duc_storage_command": "duc ls -d /project/.duc_databases/rrg-bengioy-ad.sqlite /project/rrg-bengioy-ad",
             "diskusage_report_command": "diskusage_report --project --all_users",
             "prometheus_url": "https://mila-thanos.calculquebec.ca",
-            "prometheus_headers_file": "secrets/drac_prometheus/headers.json",
+            "prometheus_headers_file": "../SARC_secrets/secrets/drac_prometheus/headers.json",
             "start_date": "2022-04-01",
             "rgu_start_date": "2023-11-28",
-            "gpu_to_rgu_billing": "secrets/gpu_to_rgu_billing_narval.json",
+            "gpu_to_rgu_billing": "../SARC_secrets/secrets/gpu_to_rgu_billing_narval.json",
             "gpus_per_nodes": {
                 "__DEFAULTS__": {
                     "a100": "A100-SXM4-40GB",
@@ -119,10 +119,10 @@
             "duc_storage_command": "duc ls -d /project/.duc_databases/rrg-bengioy-ad.sqlite /project/rrg-bengioy-ad",
             "diskusage_report_command": "diskusage_report --project --all_users",
             "prometheus_url": "https://mila-thanos.calculquebec.ca",
-            "prometheus_headers_file": "secrets/drac_prometheus/headers.json",
+            "prometheus_headers_file": "../SARC_secrets/secrets/drac_prometheus/headers.json",
             "start_date": "2022-04-01",
             "rgu_start_date": "2024-04-03",
-            "gpu_to_rgu_billing": "secrets/gpu_to_rgu_billing_beluga.json",
+            "gpu_to_rgu_billing": "../SARC_secrets/secrets/gpu_to_rgu_billing_beluga.json",
             "gpus_per_nodes": {
                 "__DEFAULTS__": {
                     "tesla_v100-sxm2-16gb": "V100-SXM2-16GB",
@@ -142,7 +142,7 @@
             "prometheus_headers_file": null,
             "start_date": "2022-04-01",
             "rgu_start_date": "2024-04-03",
-            "gpu_to_rgu_billing": "secrets/gpu_to_rgu_billing_graham.json",
+            "gpu_to_rgu_billing": "../SARC_secrets/secrets/gpu_to_rgu_billing_graham.json",
             "gpus_per_nodes": {
                 "gra[828-987]": {
                     "p100": "P100-PCIe-12GB"
@@ -179,7 +179,7 @@
             "prometheus_headers_file": null,
             "start_date": "2022-04-01",
             "rgu_start_date": "2024-04-03",
-            "gpu_to_rgu_billing": "secrets/gpu_to_rgu_billing_cedar.json",
+            "gpu_to_rgu_billing": "../SARC_secrets/secrets/gpu_to_rgu_billing_cedar.json",
             "gpus_per_nodes": {
                 "__DEFAULTS__": {
                     "p100": "P100-PCIe-12GB",

--- a/config/sarc-prod.json
+++ b/config/sarc-prod.json
@@ -9,17 +9,17 @@
         "database_name": "sarc"
     },
     "ldap": {
-        "local_private_key_file": "secrets/ldap/Google_2026_01_26_66827.key",
-        "local_certificate_file": "secrets/ldap/Google_2026_01_26_66827.crt",
+        "local_private_key_file": "../SARC_secrets/secrets/ldap/Google_2026_01_26_66827.key",
+        "local_certificate_file": "../SARC_secrets/secrets/ldap/Google_2026_01_26_66827.crt",
         "ldap_service_uri": "ldaps://ldap.google.com",
         "mongo_collection_name": "users",
-        "group_to_prof_json_path": "secrets/group_to_prof.json",
-        "exceptions_json_path": "secrets/exceptions.json"
+        "group_to_prof_json_path": "../SARC_secrets/secrets/group_to_prof.json",
+        "exceptions_json_path": "../SARC_secrets/secrets/exceptions.json"
     },
     "account_matching": {
-        "drac_members_csv_path": "secrets/account_matching/members-rrg-bengioy-ad-2022-11-25.csv",
-        "drac_roles_csv_path": "secrets/account_matching/sponsored_roles_for_Yoshua_Bengio_(CCI_jvb-000).csv",
-        "make_matches_config": "secrets/account_matching/make_matches_config.json"
+        "drac_members_csv_path": "../SARC_secrets/secrets/account_matching/members-rrg-bengioy-ad-2022-11-25.csv",
+        "drac_roles_csv_path": "../SARC_secrets/secrets/account_matching/sponsored_roles_for_Yoshua_Bengio_(CCI_jvb-000).csv",
+        "make_matches_config": "../SARC_secrets/secrets/account_matching/make_matches_config.json"
     },
     "cache": "./sarc-cache",
     "sshconfig": "~/.ssh/config",
@@ -45,10 +45,10 @@
             "duc_storage_command": "duc ls -d /project/.duc_databases/rrg-bengioy-ad.sqlite /project/rrg-bengioy-ad",
             "diskusage_report_command": "diskusage_report --project --all_users",
             "prometheus_url": "https://mila-thanos.calculquebec.ca",
-            "prometheus_headers_file": "secrets/drac_prometheus/headers.json",
+            "prometheus_headers_file": "../SARC_secrets/secrets/drac_prometheus/headers.json",
             "start_date": "2022-04-01",
             "rgu_start_date": "2023-11-28",
-            "gpu_to_rgu_billing": "secrets/gpu_to_rgu_billing_narval.json"
+            "gpu_to_rgu_billing": "../SARC_secrets/secrets/gpu_to_rgu_billing_narval.json"
         },
         "beluga": {
             "host": "beluga.computecanada.ca",
@@ -59,10 +59,10 @@
             "duc_storage_command": "duc ls -d /project/.duc_databases/rrg-bengioy-ad.sqlite /project/rrg-bengioy-ad",
             "diskusage_report_command": "diskusage_report --project --all_users",
             "prometheus_url": "https://mila-thanos.calculquebec.ca",
-            "prometheus_headers_file": "secrets/drac_prometheus/headers.json",
+            "prometheus_headers_file": "../SARC_secrets/secrets/drac_prometheus/headers.json",
             "start_date": "2022-04-01",
             "rgu_start_date": "2024-04-03",
-            "gpu_to_rgu_billing": "secrets/gpu_to_rgu_billing_beluga.json"
+            "gpu_to_rgu_billing": "../SARC_secrets/secrets/gpu_to_rgu_billing_beluga.json"
         },
         "graham": {
             "host": "graham.computecanada.ca",
@@ -76,7 +76,7 @@
             "prometheus_headers_file": null,
             "start_date": "2022-04-01",
             "rgu_start_date": "2024-04-03",
-            "gpu_to_rgu_billing": "secrets/gpu_to_rgu_billing_graham.json"
+            "gpu_to_rgu_billing": "../SARC_secrets/secrets/gpu_to_rgu_billing_graham.json"
         },
         "cedar": {
             "host": "cedar.computecanada.ca",
@@ -90,7 +90,7 @@
             "prometheus_headers_file": null,
             "start_date": "2022-04-01",
             "rgu_start_date": "2024-04-03",
-            "gpu_to_rgu_billing": "secrets/gpu_to_rgu_billing_cedar.json"
+            "gpu_to_rgu_billing": "../SARC_secrets/secrets/gpu_to_rgu_billing_cedar.json"
         }
     }
 }

--- a/docs/account_matching.md
+++ b/docs/account_matching.md
@@ -25,8 +25,8 @@ We will explain the pipeline from Mila LDAP and CC reports to populate those ent
 export MONGODB_CONNECTION_STRING='mongodb://127.0.0.1:27017'
 
 python3 sarc/users/read_mila_ldap.py \
-    --local_private_key_file secrets/ldap/Google_2026_01_26_66827.key \
-    --local_certificate_file secrets/ldap/Google_2026_01_26_66827.crt \
+    --local_private_key_file ../SARC_secrets/secrets/ldap/Google_2026_01_26_66827.key \
+    --local_certificate_file ../SARC_secrets/secrets/ldap/Google_2026_01_26_66827.crt \
     --ldap_service_uri ldaps://ldap.google.com \
     --mongodb_connection_string ${MONGODB_CONNECTION_STRING} \
     --output_json_file mila_users.json
@@ -34,7 +34,7 @@ python3 sarc/users/read_mila_ldap.py \
 
 This command has two effects:
 - It updates the values in the database collection "users".
-- It generates a file like the one found in `secrets/account_matching/2022-11-26_mila_users.json`.
+- It generates a file like the one found in `../SARC_secrets/secrets/account_matching/2022-11-26_mila_users.json`.
 
 When the `--mongodb_connection_string` argument is omitted, nothing happens with the database.
 
@@ -63,10 +63,10 @@ This script could be rewritten to avoid such a situation.
 export PYTHONPATH=$PYTHONPATH:`pwd`
 
 python3 sarc/account_matching/make_matches.py \
-    --config_path secrets/account_matching/make_matches_config.json \
-    --mila_ldap_path secrets/account_matching/2022-11-26_mila_users.json \
-    --drac_members_path secrets/account_matching/members-rrg-bengioy-ad-2022-11-25.csv \
-    --drac_roles_path 'secrets/account_matching/sponsored_roles_for_Yoshua_Bengio_(CCI_jvb-000).csv' \
+    --config_path ../SARC_secrets/secrets/account_matching/make_matches_config.json \
+    --mila_ldap_path ../SARC_secrets/secrets/account_matching/2022-11-26_mila_users.json \
+    --drac_members_path ../SARC_secrets/secrets/account_matching/members-rrg-bengioy-ad-2022-11-25.csv \
+    --drac_roles_path '../SARC_secrets/secrets/account_matching/sponsored_roles_for_Yoshua_Bengio_(CCI_jvb-000).csv' \
     --output_path matches_done.json
 ```
 

--- a/docs/account_matching_manual_procedure.md
+++ b/docs/account_matching_manual_procedure.md
@@ -6,10 +6,10 @@ The manual procedure steps are:
 
 **Once a month** (or each time we have new users files from DRAC):
 
-- Copy the two DRAC files (`users` and `roles`) in the `secrets/account_matching` folder
+- Copy the two DRAC files (`users` and `roles`) in the `../SARC_secrets/secrets/account_matching` folder
 - Adjust the `account_matching` section of the config file to point to these two files 
 - run the `acquire users` command
-- if any errors, adjust the exceptions in the `secrets/make_matches_config.json` file, and re-run the account matching script.
+- if any errors, adjust the exceptions in the `../SARC_secrets/secrets/make_matches_config.json` file, and re-run the account matching script.
 
 ## In details
 
@@ -46,13 +46,13 @@ To use the remote mongoDB connection, tunneled from localhost:27018, the `mongo`
 
 ### data source 1: Mila LDAP credentials
 
-The credentials for the Mila LDAP are in the `secrets/ldap` folder.
+The credentials for the Mila LDAP are in the `../SARC_secrets/secrets/ldap` folder.
 
 They are refered to in the ldap section of the sarc config file :
 ```
     "ldap": {
-        "local_private_key_file": "secrets/ldap/Google_2026_01_26_66827.key",
-        "local_certificate_file": "secrets/ldap/Google_2026_01_26_66827.crt",
+        "local_private_key_file": "../SARC_secrets/secrets/ldap/Google_2026_01_26_66827.key",
+        "local_certificate_file": "../SARC_secrets/secrets/ldap/Google_2026_01_26_66827.crt",
         "ldap_service_uri": "ldaps://ldap.google.com",
         "mongo_collection_name": "users"
     },
@@ -67,7 +67,7 @@ Compute Canada must provide 2 CSV files:
 
 #### copy the files in the right directory
 
-The two file must be copied to the `secrets/account_matching/` folder of SARC, on the server or the local machine, depending on the scenario. 
+The two file must be copied to the `../SARC_secrets/secrets/account_matching/` folder of SARC, on the server or the local machine, depending on the scenario. 
 
 #### Configuration file
 
@@ -75,7 +75,7 @@ The two file must be copied to the `secrets/account_matching/` folder of SARC, o
 
 ### Exceptions handling
 
-The exception are manually handled in the `secrets/make_matches_config.json` file.
+The exception are manually handled in the `../SARC_secrets/secrets/make_matches_config.json` file.
 
 ```
 {

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -68,9 +68,9 @@ Ensure that uv is either available on $PATH or is at a known location
 
 You have 3 mongo users account; 
 
-- `mongoadmin` (password: see `secrets/mongo_admin_password.txt`) is the global mongodb administrator account.
+- `mongoadmin` (password: see `../SARC_secrets/secrets/mongo_admin_password.txt`) is the global mongodb administrator account.
 - `readuser`(password: `readpwd`, see `config/sarc-client.json`) is the user for general use (only reads data from the database)
-- `writeuser` (password: see `secrets/mongo_writeuser_password.txt`) is used by the server during scraping
+- `writeuser` (password: see `../SARC_secrets/secrets/mongo_writeuser_password.txt`) is used by the server during scraping
 
 Therefore, if you want to admin the database with compass, the connection string will be (see `config/sarc-*.json`) :
 ```

--- a/docs/dev_overview/secrets.md
+++ b/docs/dev_overview/secrets.md
@@ -1,33 +1,33 @@
-# `secrets/` folder
+# `secrets` folder
 
 Some files need to be available for SARC to work properly. These files are private and cannot be stored on this repository.
 
-They must be stored in the `secrets/` folder of root `SARC` folder.
+They must be stored in the `../SARC_secrets/secrets/` folder. It is important to keep it outside the `SARC` repo clone, especially if you use a LLM assistant like `Cursor`, `Copilot` or whatever else could scan the entirety of the project folder.
 
 Many of these files are referenced from the sarc-xxxx.json config file; example:
 
 ```json
     "ldap": {
-        "local_private_key_file": "secrets/ldap/Google_2026_01_26_66827.key",
-        "local_certificate_file": "secrets/ldap/Google_2026_01_26_66827.crt",
+        "local_private_key_file": "../SARC_secrets/secrets/ldap/Google_2026_01_26_66827.key",
+        "local_certificate_file": "../SARC_secrets/secrets/ldap/Google_2026_01_26_66827.crt",
         "ldap_service_uri": "ldaps://ldap.google.com",
         "mongo_collection_name": "users",
-        "group_to_prof_json_path": "secrets/group_to_prof.json",
-        "exceptions_json_path": "secrets/exceptions.json"
+        "group_to_prof_json_path": "../SARC_secrets/secrets/group_to_prof.json",
+        "exceptions_json_path": "../SARC_secrets/secrets/exceptions.json"
     },
     "account_matching": {
-        "drac_members_csv_path": "secrets/account_matching/members-rrg-bengioy-ad-2022-11-25.csv",
-        "drac_roles_csv_path": "secrets/account_matching/sponsored_roles_for_Yoshua_Bengio_(CCI_jvb-000).csv",
-        "make_matches_config": "secrets/account_matching/make_matches_config.json"
+        "drac_members_csv_path": "../SARC_secrets/secrets/account_matching/members-rrg-bengioy-ad-2022-11-25.csv",
+        "drac_roles_csv_path": "../SARC_secrets/secrets/account_matching/sponsored_roles_for_Yoshua_Bengio_(CCI_jvb-000).csv",
+        "make_matches_config": "../SARC_secrets/secrets/account_matching/make_matches_config.json"
     },
 ```
 ... or in the `clusters` section:
 ```json
         "narval": {
             (...)
-            "prometheus_headers_file": "secrets/drac_prometheus/headers.json",
+            "prometheus_headers_file": "../SARC_secrets/secrets/drac_prometheus/headers.json",
             (...)
-            "gpu_to_rgu_billing": "secrets/gpu_to_rgu_billing_narval.json"
+            "gpu_to_rgu_billing": "../SARC_secrets/secrets/gpu_to_rgu_billing_narval.json"
         }
 ```
 

--- a/docs/dev_overview/users.md
+++ b/docs/dev_overview/users.md
@@ -10,9 +10,9 @@ source code: [sarc/cli/acquire/users.py](../../sarc/cli/acquire/users.py)
 
 The acocunt atching code meerges different sources of informations to match the mila credentials with the DRAC credentials:
 - LDAP
-- DRAC CSVs, manually downloaded and placed in the `secrets/` folder
+- DRAC CSVs, manually downloaded and placed in the `../SARC_secrets/secrets/` folder
 - mymila (deactivated until further notice)
-- exception files (in the `secrets/` folder, see [secrets](secrets.md) for more informations)
+- exception files (in the `../SARC_secrets/secrets/` folder, see [secrets](secrets.md) for more informations)
 
 ## Users revisions
 

--- a/sarc/account_matching/make_matches.py
+++ b/sarc/account_matching/make_matches.py
@@ -10,7 +10,7 @@ we have to keep this private, despite how convenient it would be at times to
 have some statements like `if name == "johnappleseed@mila.quebec"`.
 
 These all need to come from a specific configuration file, and that file is include
-with the other secrets in the "secrets/account_matching" directory.
+with the other secrets in the "../SARC_secrets/secrets/account_matching" directory.
 """
 
 import copy

--- a/sarc/users/read_mila_ldap.py
+++ b/sarc/users/read_mila_ldap.py
@@ -48,8 +48,8 @@ Two ways this can be used:
 ::
 
     python3 read_mila_ldap.py \\
-        --local_private_key_file secrets/Google_2026_01_26_66827.key \\
-        --local_certificate_file secrets/Google_2026_01_26_66827.crt \\
+        --local_private_key_file ../SARC_secrets/secrets/Google_2026_01_26_66827.key \\
+        --local_certificate_file ../SARC_secrets/secrets/Google_2026_01_26_66827.crt \\
         --ldap_service_uri ldaps://ldap.google.com \\
         --mongodb_connection_string ${MONGODB_CONNECTION_STRING} \\
         --output_json_file mila_users.json

--- a/scripts/systemd/mongo_backup.sh
+++ b/scripts/systemd/mongo_backup.sh
@@ -30,7 +30,7 @@ if [ -z "$4" ]
   then
     SCRIPT=$(readlink -f "$0")
     SCRIPTPATH=$(dirname "$SCRIPT")
-    SECRET_PATH=$SCRIPTPATH/../../secrets/mongo_writeuser_password.txt
+    SECRET_PATH=$SCRIPTPATH/../../../SARC_secrets/secrets/mongo_writeuser_password.txt
     echo "No secret file path supplied, using default path $SECRET_PATH"
   else
     SECRET_PATH=$4

--- a/scripts/systemd/sarc_backup.service
+++ b/scripts/systemd/sarc_backup.service
@@ -7,7 +7,7 @@ Type=oneshot
 # this hard-coded path is UGLY as hell.
 # replace it asap as soone as we know a way to
 # dynamically determine the dirpath of this script
-ExecStart=sudo -u sarc /bin/bash /home/sarc/SARC/scripts/systemd/mongo_backup.sh sarc_mongo sarc /home/sarc/mongo_backups/ /home/sarc/SARC/secrets/mongo_writeuser_password.txt
+ExecStart=sudo -u sarc /bin/bash /home/sarc/SARC/scripts/systemd/mongo_backup.sh sarc_mongo sarc /home/sarc/mongo_backups/ /home/sarc/SARC_secrets/secrets/mongo_writeuser_password.txt
 ExecStart=mkdir -p /backup
 ExecStart=cp /home/sarc/mongo_backups/daily_backup.tar.gz /backup/
 

--- a/tests/sarc-test.json
+++ b/tests/sarc-test.json
@@ -13,11 +13,11 @@
         "local_certificate_file": "not_a_valid_path.crt",
         "ldap_service_uri": "ldaps://ldap.google.com",
         "mongo_collection_name": "users",
-        "group_to_prof_json_path": "secrets/group_to_prof.json",
-        "exceptions_json_path": "secrets/exceptions.json"
+        "group_to_prof_json_path": "../SARC_secrets/secrets/group_to_prof.json",
+        "exceptions_json_path": "../SARC_secrets/secrets/exceptions.json"
     },
     "mymila": {
-        "tmp_json_path": "secrets/tmp_mymila.json"
+        "tmp_json_path": "../SARC_secrets/secrets/tmp_mymila.json"
     },
     "account_matching": {
         "drac_members_csv_path": "drac_members_not_valid_path.csv",


### PR DESCRIPTION
The goal is to move the `secrets` folder outside of the SARC folder, so that no LLM assistant working on the SARC folder could parse the secrets files.
Only references to the folder and documentations  are affected, since the `secrets/` folder itself is not published in the git repo.