### PR TITLE
[SARC-381] Prometheus: mettre en place un cache

### DIFF
--- a/tests/functional/jobs/test_func_get_job_time_series.py
+++ b/tests/functional/jobs/test_func_get_job_time_series.py
@@ -40,6 +40,7 @@ def test_no_job_with_this_id(job):
     assert get_job_time_series(job, "slurm_job_core_usage", dataframe=True) is None
 
 
+@pytest.mark.usefixtures("standard_config")
 def test_non_existing_metric(job):
     with pytest.raises(ValueError, match="^Unknown metric name: non_existing_metric"):
         get_job_time_series(job, "non_existing_metric", dataframe=True)
@@ -92,6 +93,7 @@ no_duration_parameters = {
 
 
 @pytest.mark.freeze_time(test_time_str)
+@pytest.mark.usefixtures("standard_config")
 @pytest.mark.parametrize(
     "job",
     no_duration_parameters.values(),
@@ -124,6 +126,7 @@ def test_measure_and_aggregation(
     file_regression.check(prom_custom_query_mock.call_args[0][0])
 
 
+@pytest.mark.usefixtures("standard_config")
 def test_invalid_aggregation(job):
     with pytest.raises(
         ValueError,

--- a/tests/functional/jobs/test_func_sacct/test_tracer_with_multiple_clusters_and_dates_and_prometheus.txt
+++ b/tests/functional/jobs/test_func_sacct/test_tracer_with_multiple_clusters_and_dates_and_prometheus.txt
@@ -228,7 +228,7 @@ Found 4 job(s):
     }
 }
 
-Found 74 span(s):
+Found 114 span(s):
 [
  {
   "span_name": "acquire_cluster_data",
@@ -304,7 +304,7 @@ Found 74 span(s):
   "span_has_error": false
  },
  {
-  "span_name": "get_job_time_series",
+  "span_name": "_get_job_time_series_data",
   "span_events": [],
   "span_attributes": {},
   "span_has_error": false
@@ -316,7 +316,7 @@ Found 74 span(s):
   "span_has_error": false
  },
  {
-  "span_name": "get_job_time_series",
+  "span_name": "_get_job_time_series_data",
   "span_events": [],
   "span_attributes": {},
   "span_has_error": false
@@ -328,7 +328,7 @@ Found 74 span(s):
   "span_has_error": false
  },
  {
-  "span_name": "get_job_time_series",
+  "span_name": "_get_job_time_series_data",
   "span_events": [],
   "span_attributes": {},
   "span_has_error": false
@@ -340,13 +340,67 @@ Found 74 span(s):
   "span_has_error": false
  },
  {
-  "span_name": "get_job_time_series",
+  "span_name": "_get_job_time_series_data",
   "span_events": [],
   "span_attributes": {},
   "span_has_error": false
  },
  {
   "span_name": "get_job_time_series",
+  "span_events": [],
+  "span_attributes": {},
+  "span_has_error": false
+ },
+ {
+  "span_name": "_get_job_time_series_data",
+  "span_events": [],
+  "span_attributes": {},
+  "span_has_error": false
+ },
+ {
+  "span_name": "get_job_time_series",
+  "span_events": [],
+  "span_attributes": {},
+  "span_has_error": false
+ },
+ {
+  "span_name": "_get_job_time_series_data",
+  "span_events": [],
+  "span_attributes": {},
+  "span_has_error": false
+ },
+ {
+  "span_name": "get_job_time_series",
+  "span_events": [],
+  "span_attributes": {},
+  "span_has_error": false
+ },
+ {
+  "span_name": "_get_job_time_series_data",
+  "span_events": [],
+  "span_attributes": {},
+  "span_has_error": false
+ },
+ {
+  "span_name": "get_job_time_series",
+  "span_events": [],
+  "span_attributes": {},
+  "span_has_error": false
+ },
+ {
+  "span_name": "_get_job_time_series_data",
+  "span_events": [],
+  "span_attributes": {},
+  "span_has_error": false
+ },
+ {
+  "span_name": "get_job_time_series",
+  "span_events": [],
+  "span_attributes": {},
+  "span_has_error": false
+ },
+ {
+  "span_name": "_get_job_time_series_data",
   "span_events": [],
   "span_attributes": {},
   "span_has_error": false
@@ -359,6 +413,12 @@ Found 74 span(s):
  },
  {
   "span_name": "get_job_time_series",
+  "span_events": [],
+  "span_attributes": {},
+  "span_has_error": false
+ },
+ {
+  "span_name": "_get_job_time_series_data",
   "span_events": [],
   "span_attributes": {},
   "span_has_error": false
@@ -412,7 +472,7 @@ Found 74 span(s):
   "span_has_error": false
  },
  {
-  "span_name": "get_job_time_series",
+  "span_name": "_get_job_time_series_data",
   "span_events": [],
   "span_attributes": {},
   "span_has_error": false
@@ -424,7 +484,7 @@ Found 74 span(s):
   "span_has_error": false
  },
  {
-  "span_name": "get_job_time_series",
+  "span_name": "_get_job_time_series_data",
   "span_events": [],
   "span_attributes": {},
   "span_has_error": false
@@ -436,7 +496,7 @@ Found 74 span(s):
   "span_has_error": false
  },
  {
-  "span_name": "get_job_time_series",
+  "span_name": "_get_job_time_series_data",
   "span_events": [],
   "span_attributes": {},
   "span_has_error": false
@@ -448,13 +508,67 @@ Found 74 span(s):
   "span_has_error": false
  },
  {
-  "span_name": "get_job_time_series",
+  "span_name": "_get_job_time_series_data",
   "span_events": [],
   "span_attributes": {},
   "span_has_error": false
  },
  {
   "span_name": "get_job_time_series",
+  "span_events": [],
+  "span_attributes": {},
+  "span_has_error": false
+ },
+ {
+  "span_name": "_get_job_time_series_data",
+  "span_events": [],
+  "span_attributes": {},
+  "span_has_error": false
+ },
+ {
+  "span_name": "get_job_time_series",
+  "span_events": [],
+  "span_attributes": {},
+  "span_has_error": false
+ },
+ {
+  "span_name": "_get_job_time_series_data",
+  "span_events": [],
+  "span_attributes": {},
+  "span_has_error": false
+ },
+ {
+  "span_name": "get_job_time_series",
+  "span_events": [],
+  "span_attributes": {},
+  "span_has_error": false
+ },
+ {
+  "span_name": "_get_job_time_series_data",
+  "span_events": [],
+  "span_attributes": {},
+  "span_has_error": false
+ },
+ {
+  "span_name": "get_job_time_series",
+  "span_events": [],
+  "span_attributes": {},
+  "span_has_error": false
+ },
+ {
+  "span_name": "_get_job_time_series_data",
+  "span_events": [],
+  "span_attributes": {},
+  "span_has_error": false
+ },
+ {
+  "span_name": "get_job_time_series",
+  "span_events": [],
+  "span_attributes": {},
+  "span_has_error": false
+ },
+ {
+  "span_name": "_get_job_time_series_data",
   "span_events": [],
   "span_attributes": {},
   "span_has_error": false
@@ -467,6 +581,12 @@ Found 74 span(s):
  },
  {
   "span_name": "get_job_time_series",
+  "span_events": [],
+  "span_attributes": {},
+  "span_has_error": false
+ },
+ {
+  "span_name": "_get_job_time_series_data",
   "span_events": [],
   "span_attributes": {},
   "span_has_error": false
@@ -551,7 +671,7 @@ Found 74 span(s):
   "span_has_error": false
  },
  {
-  "span_name": "get_job_time_series",
+  "span_name": "_get_job_time_series_data",
   "span_events": [],
   "span_attributes": {},
   "span_has_error": false
@@ -563,7 +683,7 @@ Found 74 span(s):
   "span_has_error": false
  },
  {
-  "span_name": "get_job_time_series",
+  "span_name": "_get_job_time_series_data",
   "span_events": [],
   "span_attributes": {},
   "span_has_error": false
@@ -575,7 +695,7 @@ Found 74 span(s):
   "span_has_error": false
  },
  {
-  "span_name": "get_job_time_series",
+  "span_name": "_get_job_time_series_data",
   "span_events": [],
   "span_attributes": {},
   "span_has_error": false
@@ -587,13 +707,67 @@ Found 74 span(s):
   "span_has_error": false
  },
  {
-  "span_name": "get_job_time_series",
+  "span_name": "_get_job_time_series_data",
   "span_events": [],
   "span_attributes": {},
   "span_has_error": false
  },
  {
   "span_name": "get_job_time_series",
+  "span_events": [],
+  "span_attributes": {},
+  "span_has_error": false
+ },
+ {
+  "span_name": "_get_job_time_series_data",
+  "span_events": [],
+  "span_attributes": {},
+  "span_has_error": false
+ },
+ {
+  "span_name": "get_job_time_series",
+  "span_events": [],
+  "span_attributes": {},
+  "span_has_error": false
+ },
+ {
+  "span_name": "_get_job_time_series_data",
+  "span_events": [],
+  "span_attributes": {},
+  "span_has_error": false
+ },
+ {
+  "span_name": "get_job_time_series",
+  "span_events": [],
+  "span_attributes": {},
+  "span_has_error": false
+ },
+ {
+  "span_name": "_get_job_time_series_data",
+  "span_events": [],
+  "span_attributes": {},
+  "span_has_error": false
+ },
+ {
+  "span_name": "get_job_time_series",
+  "span_events": [],
+  "span_attributes": {},
+  "span_has_error": false
+ },
+ {
+  "span_name": "_get_job_time_series_data",
+  "span_events": [],
+  "span_attributes": {},
+  "span_has_error": false
+ },
+ {
+  "span_name": "get_job_time_series",
+  "span_events": [],
+  "span_attributes": {},
+  "span_has_error": false
+ },
+ {
+  "span_name": "_get_job_time_series_data",
   "span_events": [],
   "span_attributes": {},
   "span_has_error": false
@@ -606,6 +780,12 @@ Found 74 span(s):
  },
  {
   "span_name": "get_job_time_series",
+  "span_events": [],
+  "span_attributes": {},
+  "span_has_error": false
+ },
+ {
+  "span_name": "_get_job_time_series_data",
   "span_events": [],
   "span_attributes": {},
   "span_has_error": false
@@ -659,7 +839,7 @@ Found 74 span(s):
   "span_has_error": false
  },
  {
-  "span_name": "get_job_time_series",
+  "span_name": "_get_job_time_series_data",
   "span_events": [],
   "span_attributes": {},
   "span_has_error": false
@@ -671,7 +851,7 @@ Found 74 span(s):
   "span_has_error": false
  },
  {
-  "span_name": "get_job_time_series",
+  "span_name": "_get_job_time_series_data",
   "span_events": [],
   "span_attributes": {},
   "span_has_error": false
@@ -683,7 +863,7 @@ Found 74 span(s):
   "span_has_error": false
  },
  {
-  "span_name": "get_job_time_series",
+  "span_name": "_get_job_time_series_data",
   "span_events": [],
   "span_attributes": {},
   "span_has_error": false
@@ -695,13 +875,67 @@ Found 74 span(s):
   "span_has_error": false
  },
  {
-  "span_name": "get_job_time_series",
+  "span_name": "_get_job_time_series_data",
   "span_events": [],
   "span_attributes": {},
   "span_has_error": false
  },
  {
   "span_name": "get_job_time_series",
+  "span_events": [],
+  "span_attributes": {},
+  "span_has_error": false
+ },
+ {
+  "span_name": "_get_job_time_series_data",
+  "span_events": [],
+  "span_attributes": {},
+  "span_has_error": false
+ },
+ {
+  "span_name": "get_job_time_series",
+  "span_events": [],
+  "span_attributes": {},
+  "span_has_error": false
+ },
+ {
+  "span_name": "_get_job_time_series_data",
+  "span_events": [],
+  "span_attributes": {},
+  "span_has_error": false
+ },
+ {
+  "span_name": "get_job_time_series",
+  "span_events": [],
+  "span_attributes": {},
+  "span_has_error": false
+ },
+ {
+  "span_name": "_get_job_time_series_data",
+  "span_events": [],
+  "span_attributes": {},
+  "span_has_error": false
+ },
+ {
+  "span_name": "get_job_time_series",
+  "span_events": [],
+  "span_attributes": {},
+  "span_has_error": false
+ },
+ {
+  "span_name": "_get_job_time_series_data",
+  "span_events": [],
+  "span_attributes": {},
+  "span_has_error": false
+ },
+ {
+  "span_name": "get_job_time_series",
+  "span_events": [],
+  "span_attributes": {},
+  "span_has_error": false
+ },
+ {
+  "span_name": "_get_job_time_series_data",
   "span_events": [],
   "span_attributes": {},
   "span_has_error": false
@@ -714,6 +948,12 @@ Found 74 span(s):
  },
  {
   "span_name": "get_job_time_series",
+  "span_events": [],
+  "span_attributes": {},
+  "span_has_error": false
+ },
+ {
+  "span_name": "_get_job_time_series_data",
   "span_events": [],
   "span_attributes": {},
   "span_has_error": false


### PR DESCRIPTION
- Cache results from get_job_time_series()
- Add CachePolicy.check to allow checking cache against live data
- Currently use CachePolicy.check in get_job_time_series() to check if collected prometheus data are the same for a given job in two different calls.