### PR TITLE
replace print by logging messages during account matching

### DIFF
--- a/sarc/account_matching/make_matches.py
+++ b/sarc/account_matching/make_matches.py
@@ -334,19 +334,24 @@ def _manual_matching(DLD_data, DD_persons, override_matches_mila_to_cc):
             drac_account_username,
         ) in override_matches_mila_to_cc.items():
             if mila_email_username not in DD_persons:
-                raise ValueError(
-                    f'"{mila_email_username}" is not found in the actual sources.'
-                    "This was supplied to `override_matches_mila_to_cc` in the `make_matches.py` file, "
+                msg = (
+                    f'"{mila_email_username}" is not found in the actual sources.\n'
+                    f"This was supplied to `override_matches_mila_to_cc` in the `make_matches.py` file, "
                     f"but there are not such entries in LDAP.\n"
-                    "Someone messed up the manual matching by specifying a Mila email username that does not exist."
+                    f"Someone messed up the manual matching by specifying a Mila email username that does not exist, or not ANYMORE."
                 )
-            # Note that `matching[drac_account_username]` is itself a dict
-            # with user information from CC. It's not just a username string.
-            if drac_account_username in matching:
-                assert isinstance(matching[drac_account_username], dict)
-                DD_persons[mila_email_username][drac_source] = matching[
-                    drac_account_username
-                ]
+                # we don't want to raise an error here because it will break the pipeline
+                # we will just log the error and move on
+                logging.error(msg)
+                # raise ValueError(msg)
+            else:
+                # Note that `matching[drac_account_username]` is itself a dict
+                # with user information from CC. It's not just a username string.
+                if drac_account_username in matching:
+                    assert isinstance(matching[drac_account_username], dict)
+                    DD_persons[mila_email_username][drac_source] = matching[
+                        drac_account_username
+                    ]
 
 
 def _make_matches_status_report(DLD_data, DD_persons):

--- a/sarc/users/supervisor.py
+++ b/sarc/users/supervisor.py
@@ -1,3 +1,4 @@
+import logging
 import re
 from dataclasses import dataclass, field
 from itertools import chain
@@ -136,17 +137,17 @@ class SupervisorMatchingErrors:
 
         def show_error(msg, array):
             if len(array) > 0:
-                print(f"{msg} {make_list(array)}")
+                logging.error(f"{msg} {make_list(array)}")
 
         show_error("     Missing supervisors:", self.no_supervisors)
         show_error("    Too many supervisors:", self.too_many_supervisors)
         show_error("        Prof and Student:", self.prof_and_student)
 
         if self.unknown_supervisors:
-            print(f"     Unknown supervisors: {self.unknown_supervisors}")
+            logging.warning(f"     Unknown supervisors: {self.unknown_supervisors}")
 
         if self.unknown_group:
-            print(f"           Unknown group: {self.unknown_group}")
+            logging.warning(f"           Unknown group: {self.unknown_group}")
 
 
 def _extract_supervisors_from_groups(


### PR DESCRIPTION
Errors and warning messages during account matching were not forwarded to loki, because the messages were using `print` and not `logging.error`/ `logging.warning`.
Also, an exception was raised if an error was detected in the exception files, breaking the process of users update.

This PR aims to fix these.