### PR TITLE
Fix tqdm errors in tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "numpy>=2.2.4,<2.3",
     "ldap3>=2.9.1,<3",
     "python-hostlist>=2.2.1,<3",
-    "tqdm>=4.64.1,<5",
+    "tqdm>=4.66,<5",
     "flatten-dict>=0.4.2,<0.5",
     "simple-parsing>=0.1.0,<0.2",
     "sphinx>=8.2.3,<9",
@@ -60,6 +60,7 @@ dev = [
     "types-requests>=2.32.0.20250328",
     "types-ldap3>=2.9.13.20240205",
     "types-tqdm>=4.67.0.20250417",
+    "pytest-env>=1.1.5",
 ]
 examples = ["seaborn>=0.13.2,<0.14"]
 
@@ -68,6 +69,9 @@ default-groups = [
     "dev",
     "examples",
 ]
+
+[tool.pytest_env]
+TQDM_DISABLE = "1"
 
 [tool.hatch.build.targets.sdist]
 include = ["sarc"]

--- a/tests/functional/usage_alerts/test_alert_cluster_scraping/test_check_nb_jobs_per_cluster_per_time_params0_.txt
+++ b/tests/functional/usage_alerts/test_alert_cluster_scraping/test_check_nb_jobs_per_cluster_per_time_params0_.txt
@@ -1,4 +1,3 @@
-load job series:   0%|          | 0/2 [00:00<?, ?it/s]load job series: 100%|██████████| 2/2 [00:00<?, ?it/s]
 [raisin]
                            count
 timestamp                       

--- a/tests/functional/usage_alerts/test_alert_cluster_scraping/test_check_nb_jobs_per_cluster_per_time_params1_.txt
+++ b/tests/functional/usage_alerts/test_alert_cluster_scraping/test_check_nb_jobs_per_cluster_per_time_params1_.txt
@@ -1,4 +1,3 @@
-load job series:   0%|          | 0/24 [00:00<?, ?it/s]load job series: 100%|██████████| 24/24 [00:00<?, ?it/s]
 [fromage]
                            count
 timestamp                       

--- a/tests/functional/usage_alerts/test_alert_cluster_scraping/test_check_nb_jobs_per_cluster_per_time_params2_.txt
+++ b/tests/functional/usage_alerts/test_alert_cluster_scraping/test_check_nb_jobs_per_cluster_per_time_params2_.txt
@@ -1,4 +1,3 @@
-load job series:   0%|          | 0/24 [00:00<?, ?it/s]load job series: 100%|██████████| 24/24 [00:00<?, ?it/s]
 [another_cluster]
                            count
 timestamp                       

--- a/tests/functional/usage_alerts/test_alert_cluster_scraping/test_check_nb_jobs_per_cluster_per_time_params3_.txt
+++ b/tests/functional/usage_alerts/test_alert_cluster_scraping/test_check_nb_jobs_per_cluster_per_time_params3_.txt
@@ -1,4 +1,3 @@
-load job series:   0%|          | 0/24 [00:00<?, ?it/s]load job series: 100%|██████████| 24/24 [00:00<?, ?it/s]
 
 [another_cluster] threshold 0 (0.0 - 2 * 0.0). Either nb_stddev is too high, time_interval (None) is too short, or this cluster should not be currently checked
 [mila] threshold 0 (0.375 - 2 * 0.5175491695067657). Either nb_stddev is too high, time_interval (None) is too short, or this cluster should not be currently checked

--- a/uv.lock
+++ b/uv.lock
@@ -2069,6 +2069,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-env"
+version = "1.1.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/31/27f28431a16b83cab7a636dce59cf397517807d247caa38ee67d65e71ef8/pytest_env-1.1.5.tar.gz", hash = "sha256:91209840aa0e43385073ac464a554ad2947cc2fd663a9debf88d03b01e0cc1cf", size = 8911, upload-time = "2024-09-17T22:39:18.566Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/b8/87cfb16045c9d4092cfcf526135d73b88101aac83bc1adcf82dfb5fd3833/pytest_env-1.1.5-py3-none-any.whl", hash = "sha256:ce90cf8772878515c24b31cd97c7fa1f4481cd68d588419fd45f10ecaee6bc30", size = 6141, upload-time = "2024-09-17T22:39:16.942Z" },
+]
+
+[[package]]
 name = "pytest-freezegun"
 version = "0.4.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2406,6 +2418,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-custom-exit-code" },
+    { name = "pytest-env" },
     { name = "pytest-freezegun" },
     { name = "pytest-httpserver" },
     { name = "pytest-regressions" },
@@ -2447,7 +2460,7 @@ requires-dist = [
     { name = "simple-parsing", specifier = ">=0.1.0,<0.2" },
     { name = "sphinx", specifier = ">=8.2.3,<9" },
     { name = "sphinx-rtd-theme", specifier = ">=3.0.2,<4" },
-    { name = "tqdm", specifier = ">=4.64.1,<5" },
+    { name = "tqdm", specifier = ">=4.66,<5" },
     { name = "watchdog", specifier = ">=6,<7" },
 ]
 
@@ -2464,6 +2477,7 @@ dev = [
     { name = "pytest", specifier = ">=7.2.1" },
     { name = "pytest-cov", specifier = ">=4.0.0" },
     { name = "pytest-custom-exit-code", specifier = ">=0.3.0" },
+    { name = "pytest-env", specifier = ">=1.1.5" },
     { name = "pytest-freezegun", specifier = ">=0.4.2" },
     { name = "pytest-httpserver", specifier = ">=1.1.0" },
     { name = "pytest-regressions", specifier = ">=2.4.2" },


### PR DESCRIPTION
I've had problems with the tests in test_alert_cluster_scraping.py because my terminal size doesn't match the reference files.

This corrects this problem by disabling tqdm output for the tests.