### PR TITLE
Make monitor test more robust to slower file operations

### DIFF
--- a/tests/unittests/alerts/test_monitor.py
+++ b/tests/unittests/alerts/test_monitor.py
@@ -23,11 +23,16 @@ def test_monitor(beans_config, caplog):
     it = day_runner().iterate()
     next(it)  # First next() does nothing
     next(it)
-    real_time.sleep(0.1)
-    assert monitor.status == {
+    expected = {
         "evil_beans": "ERROR",
         "little_beans": "FAILURE",
         "many_beans": "OK",
     }
+    for i in range(9):
+        real_time.sleep(2**i / 100)
+        if monitor.status == expected:
+            break
+    else:
+        assert monitor.status == expected
     monitor.stop()
     monitor.join()


### PR DESCRIPTION
The test appears to fail periodically because 0.2s is too small a delay for the report files to be picked up by the monitor. This version checks in a loop that will last at most 5 seconds, which should be plenty.
