### PR TITLE
Fix compute job statistics

### DIFF
--- a/sarc/jobs/sacct.py
+++ b/sarc/jobs/sacct.py
@@ -54,7 +54,7 @@ class SAcctScraper:
         accounts = ",".join(self.cluster.accounts) if self.cluster.accounts else None
         accounts_option = f"-A {accounts}" if accounts else ""
         cmd = f"{self.cluster.sacct_bin} {accounts_option} -X -S {start} -E {end} --allusers --json"
-        logger.info(f"{self.cluster.name} $ {cmd}")
+        logger.debug(f"{self.cluster.name} $ {cmd}")
         if self.cluster.host == "localhost":
             results: subprocess.CompletedProcess[str] | Result = subprocess.run(
                 cmd, shell=True, text=True, capture_output=True, check=False

--- a/sarc/jobs/series.py
+++ b/sarc/jobs/series.py
@@ -395,15 +395,16 @@ def compute_job_statistics(job: SlurmJob) -> JobStatistics:
     )
 
     system_memory = None
-    if job.allocated.mem is None:
-        if job.job_state.value != 'CANCELED':
-            logging.warning(f"job.allocated.mem is None for job {job.job_id} (job status: {job.job_state.value})")
-    else:
+    if job.allocated.mem is not None:
         system_memory = compute_job_statistics_from_dataframe(
             metrics["slurm_job_memory_usage"],
             statistics=statistics_dict,
             normalization=lambda x: float(x / 1e6 / job.allocated.mem),
             unused_threshold=False,
+        )
+    elif metrics["slurm_job_memory_usage"] is not None:
+        logging.warning(
+            f"job.allocated.mem is None for job {job.job_id} (job status: {job.job_state.value})"
         )
 
     return JobStatistics(

--- a/sarc/jobs/series.py
+++ b/sarc/jobs/series.py
@@ -393,12 +393,13 @@ def compute_job_statistics(job: SlurmJob) -> JobStatistics:
         unused_threshold=0.01,
         is_time_counter=True,
     )
-    job_mem = job.allocated.mem
-    assert job_mem is not None
+
+    if job.allocated.mem is None:
+        logging.warning(f"job.allocated.mem is None for job {job.job_id}")
     system_memory = compute_job_statistics_from_dataframe(
         metrics["slurm_job_memory_usage"],
         statistics=statistics_dict,
-        normalization=lambda x: float(x / 1e6 / job_mem),
+        normalization=lambda x: float(x / 1e6 / job.allocated.mem),
         unused_threshold=False,
     )
 

--- a/sarc/jobs/series.py
+++ b/sarc/jobs/series.py
@@ -174,7 +174,7 @@ def _get_job_time_series_data(
     else:
         query = f"{query}[{duration_seconds}s:{interval}s] {offset_string}"
 
-    logging.info(f"prometheus query with offset: {query}")
+    logging.debug(f"prometheus query with offset: {query}")
     return job.fetch_cluster_config().prometheus.custom_query(query)
 
 

--- a/sarc/jobs/series.py
+++ b/sarc/jobs/series.py
@@ -394,14 +394,16 @@ def compute_job_statistics(job: SlurmJob) -> JobStatistics:
         is_time_counter=True,
     )
 
+    system_memory = None
     if job.allocated.mem is None:
         logging.warning(f"job.allocated.mem is None for job {job.job_id}")
-    system_memory = compute_job_statistics_from_dataframe(
-        metrics["slurm_job_memory_usage"],
-        statistics=statistics_dict,
-        normalization=lambda x: float(x / 1e6 / job.allocated.mem),
-        unused_threshold=False,
-    )
+    else:
+        system_memory = compute_job_statistics_from_dataframe(
+            metrics["slurm_job_memory_usage"],
+            statistics=statistics_dict,
+            normalization=lambda x: float(x / 1e6 / job.allocated.mem),
+            unused_threshold=False,
+        )
 
     return JobStatistics(
         gpu_utilization=Statistics(**gpu_utilization) if gpu_utilization else None,

--- a/sarc/jobs/series.py
+++ b/sarc/jobs/series.py
@@ -396,7 +396,8 @@ def compute_job_statistics(job: SlurmJob) -> JobStatistics:
 
     system_memory = None
     if job.allocated.mem is None:
-        logging.warning(f"job.allocated.mem is None for job {job.job_id}")
+        if job.job_state.value != 'CANCELED':
+            logging.warning(f"job.allocated.mem is None for job {job.job_id} (job status: {job.job_state.value})")
     else:
         system_memory = compute_job_statistics_from_dataframe(
             metrics["slurm_job_memory_usage"],

--- a/sarc/logging.py
+++ b/sarc/logging.py
@@ -38,9 +38,6 @@ def setupLogging(verbose_level: int = 0):
         "CRITICAL": logging.CRITICAL,
     }
 
-    for key, value in logging_levels.items():
-        print(f"{key}={value}")
-
     conf = config()
     # Apparently this can be called in client mode which doesn't have logging
     if hasattr(conf, "logging") and conf.logging:

--- a/sarc/logging.py
+++ b/sarc/logging.py
@@ -10,9 +10,7 @@ from opentelemetry.sdk.resources import Resource
 from sarc.config import LoggingConfig, config
 
 
-def getOpenTelemetryLoggingHandler(
-    log_conf: LoggingConfig
-):
+def getOpenTelemetryLoggingHandler(log_conf: LoggingConfig):
     logger_provider = LoggerProvider(
         resource=Resource.create(
             {
@@ -51,7 +49,7 @@ def setupLogging(verbose_level: int = 0):
         # in 0 (not specified in command line) then config log level is used
         # otherwise, command-line verbose level is used
         log_level = verbose_levels.get(verbose_level, config_log_level)
-    
+
         # Create the OpenTelemetry handler with NOTSET level
         ot_handler = getOpenTelemetryLoggingHandler(conf.logging)
 
@@ -59,12 +57,12 @@ def setupLogging(verbose_level: int = 0):
         formatter = logging.Formatter(
             "%(asctime)-15s::%(levelname)s::%(name)s::%(message)s"
         )
-        
+
         # Configure console handler
         console_handler = logging.StreamHandler()
         console_handler.setFormatter(formatter)
         console_handler.setLevel(logging.NOTSET)  # Let logger level control filtering
-        
+
         # Configure OpenTelemetry handler
         ot_handler.setFormatter(formatter)  # Apply the same formatter
         ot_handler.setLevel(logging.NOTSET)  # Let logger level control filtering
@@ -72,11 +70,11 @@ def setupLogging(verbose_level: int = 0):
         # Clear any existing handlers and configure logging
         root_logger = logging.getLogger()
         root_logger.handlers.clear()  # Remove any existing handlers
-        
+
         # Add our handlers
         root_logger.addHandler(ot_handler)
         root_logger.addHandler(console_handler)
-        
+
         # Set the logger level (this controls what messages get processed)
         root_logger.setLevel(log_level)
 


### PR DESCRIPTION
This PR addresses 2 problems:

OpenTelemetry/Loki logger config:
 - fix unreliable logger setup, leading to absence of opentelemetry log sent to loki endpoint
 - adjust a log level verbosity from INFO to DEBUG, to avoid log spamming
 
Crash during scraping:
 - remove an assert introduced by PR #206 and replace if with a logging.warning() to avoid crash during scraping, but keep a trace of the potential error in the logs