### PR TITLE
Update gpus_per_nodes for MIG GPUs on narval, and allow recursive parsing in harmonize_gpus() to rename a GPU before harmonization

### DIFF
--- a/config/sarc-dev.yaml
+++ b/config/sarc-dev.yaml
@@ -89,12 +89,17 @@ sarc:
         __DEFAULTS__:
           a100: A100-SXM4-40GB
           a100_1g.5gb: __MIG_FLAG__a100
+          1g.5gb: $a100_1g.5gb
           a100_2g.10gb: __MIG_FLAG__a100
-          2g.10gb: __MIG_FLAG__a100
+          2g.10gb: $a100_2g.10gb
           a100_3g.20gb: __MIG_FLAG__a100
-          3g.20gb: __MIG_FLAG__a100
+          3g.20gb: $a100_3g.20gb
           a100_4g.20gb: __MIG_FLAG__a100
-          4g.20gb: __MIG_FLAG__a100
+          4g.20gb: $a100_4g.20gb
+          "A100-SXM4-40GB : 1g.5gb": $a100_1g.5gb
+          "A100-SXM4-40GB : 2g.10gb": $a100_2g.10gb
+          "A100-SXM4-40GB : 3g.20gb": $a100_3g.20gb
+          "A100-SXM4-40GB : 4g.20gb": $a100_4g.20gb
           NVIDIA A100-SXM4-40GB: A100-SXM4-40GB
     beluga:
       host: beluga.computecanada.ca

--- a/config/sarc-prod.yaml
+++ b/config/sarc-prod.yaml
@@ -86,12 +86,17 @@ sarc:
         __DEFAULTS__:
           a100: A100-SXM4-40GB
           a100_1g.5gb: __MIG_FLAG__a100
+          1g.5gb: $a100_1g.5gb
           a100_2g.10gb: __MIG_FLAG__a100
-          2g.10gb: __MIG_FLAG__a100
+          2g.10gb: $a100_2g.10gb
           a100_3g.20gb: __MIG_FLAG__a100
-          3g.20gb: __MIG_FLAG__a100
+          3g.20gb: $a100_3g.20gb
           a100_4g.20gb: __MIG_FLAG__a100
-          4g.20gb: __MIG_FLAG__a100
+          4g.20gb: $a100_4g.20gb
+          "A100-SXM4-40GB : 1g.5gb": $a100_1g.5gb
+          "A100-SXM4-40GB : 2g.10gb": $a100_2g.10gb
+          "A100-SXM4-40GB : 3g.20gb": $a100_3g.20gb
+          "A100-SXM4-40GB : 4g.20gb": $a100_4g.20gb
           NVIDIA A100-SXM4-40GB: A100-SXM4-40GB
     beluga:
       host: beluga.computecanada.ca
@@ -168,11 +173,11 @@ sarc:
       timezone: America/Montreal
       accounts:
       sacct_bin: "/opt/slurm/bin/sacct"
-      duc_inodes_command: 
-      duc_storage_command: 
+      duc_inodes_command:
+      duc_storage_command:
       diskusage_report_command: diskusage_report --project --all_users
-      prometheus_url: 
-      prometheus_headers_file: 
+      prometheus_url:
+      prometheus_headers_file:
       start_date: '2025-02-01'
       gpus_per_nodes:
         __DEFAULTS__:

--- a/tests/unittests/jobs/test_harmonize_gpu.py
+++ b/tests/unittests/jobs/test_harmonize_gpu.py
@@ -3,9 +3,13 @@ import pytest
 from sarc.config import DEFAULTS_FLAG, MIG_FLAG, ClusterConfig, config
 
 GPUS_PER_NODES = {
-    "node[0-9]": {"gpu1": "DESCRIPTIVE GPU 1"},
+    "node[0-9]": {"gpu1": "DESCRIPTIVE GPU 1", "badly_named_gpu1": "$gpu1"},
     "node[9-19]": {"gpu2": "DESCRIPTIVE GPU 2"},
-    "node_mig20": {"gpu3": "DESCRIPTIVE GPU 3", "4g.40gb": f"{MIG_FLAG}gpu3"},
+    "node_mig20": {
+        "gpu3": "DESCRIPTIVE GPU 3",
+        "4g.40gb": f"{MIG_FLAG}gpu3",
+        "strange 4g 40gigabytes": "$4g.40gb",
+    },
     DEFAULTS_FLAG: {"gpu_default": "DESCRIPTIVE GPU DEFAULT"},
 }
 
@@ -26,8 +30,26 @@ GPUS_PER_NODES = {
             GPUS_PER_NODES,
         ],
         [
+            "node1",
+            "badly_named_gpu1",
+            "DESCRIPTIVE GPU 1",
+            GPUS_PER_NODES,
+        ],
+        [
             "node11",
             "GPU2",
+            "DESCRIPTIVE GPU 2",
+            GPUS_PER_NODES,
+        ],
+        [
+            "node11",
+            "gpu:GPU2",
+            "DESCRIPTIVE GPU 2",
+            GPUS_PER_NODES,
+        ],
+        [
+            "node11",
+            "gpu:gpu2:1:2:3:4:5",
             "DESCRIPTIVE GPU 2",
             GPUS_PER_NODES,
         ],
@@ -46,6 +68,12 @@ GPUS_PER_NODES = {
         [
             "node_mig20",
             "4g.40gb",
+            "DESCRIPTIVE GPU 3 : 4g.40gb",
+            GPUS_PER_NODES,
+        ],
+        [
+            "node_mig20",
+            "STRANGE 4g 40gigabytes",
             "DESCRIPTIVE GPU 3 : 4g.40gb",
             GPUS_PER_NODES,
         ],


### PR DESCRIPTION
Sur narval, on peut tomber quelques fois sur des MIG GPUs nommés `1g.5gb`, `2g.10gb`, etc ...

Or, on ne trouve pas de tels noms dans les fichiers `slurm.conf`. À la place, on a plutôt **a100**_1g.5gb, **a100**_2g.10gb, etc ...

Cette PR a pour but de s'assurer que ces noms différents de MIG GPUs sont harmonisés de la même manière, en utilisant les noms **a100**_* comme noms par défaut.