### PR TITLE
Update renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,5 +17,24 @@
       "depNameTemplate": "uv",
       "packageNameTemplate": "uv"
     }
+  ],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "automerge": true
+  },
+  "packageRules": [
+    {
+      "matchPackageNames": [
+        "uv"
+      ],
+      "automerge": true
+    },
+    {
+      "matchPackageNames": [
+        "serieux",
+        "gifnoc"
+      ],
+      "groupName": "breuleux"
+    }
   ]
 }


### PR DESCRIPTION
- Enable lockfile maintenance, which will update the versions in the lockfile while still respecting the limits in pyproject.
- Automerge uv updates since they are frequent and tested anyway
- Group updates of serieux and gifnoc since they almost always have a dependency.