### PR TITLE
update_job_series_rgu(): convert `allocated.gres_gpu` to float before update

### DIFF
--- a/sarc/client/series.py
+++ b/sarc/client/series.py
@@ -324,6 +324,9 @@ def update_job_series_rgu(df: DataFrame) -> DataFrame:
         - column `gpu_type_rgu` added or updated to contain RGU cost per GPU (RGU/GPU ratio).
           Set to NaN (or unchanged if already present) for jobs from clusters without RGU.
     """
+    # Change type of allocated.gres_gpu to float
+    df["allocated.gres_gpu"] = df["allocated.gres_gpu"].astype("float")
+
     for cluster in get_available_clusters():
         update_cluster_job_series_rgu(df, cluster.cluster_name)
     return df

--- a/tests/functional/jobs/test_func_update_job_series_rgu.py
+++ b/tests/functional/jobs/test_func_update_job_series_rgu.py
@@ -393,7 +393,9 @@ def test_update_job_series_rgu_one_date(
         expected_gres_rgu,
         expected_gpu_type_rgu,
     ) = data.get_expected()
-    assert frame["allocated.gres_gpu"].equals(pandas.Series(expected_gres_gpu))
+    assert frame["allocated.gres_gpu"].equals(
+        pandas.Series(expected_gres_gpu, dtype=float)
+    )
     assert frame["allocated.gres_rgu"].equals(pandas.Series(expected_gres_rgu))
     assert frame["allocated.gpu_type_rgu"].equals(pandas.Series(expected_gpu_type_rgu))
 
@@ -453,7 +455,9 @@ def test_update_job_series_rgu_with_many_dates(
         expected_gres_rgu,
         expected_gpu_type_rgu,
     ) = data.get_expected()
-    assert frame["allocated.gres_gpu"].equals(pandas.Series(expected_gres_gpu))
+    assert frame["allocated.gres_gpu"].equals(
+        pandas.Series(expected_gres_gpu, dtype=float)
+    )
     assert frame["allocated.gres_rgu"].equals(pandas.Series(expected_gres_rgu))
     assert frame["allocated.gpu_type_rgu"].equals(pandas.Series(expected_gpu_type_rgu))
 
@@ -514,7 +518,9 @@ def test_update_job_series_rgu_billing_is_gpu(
         expected_gres_rgu,
         expected_gpu_type_rgu,
     ) = data.get_expected()
-    assert frame["allocated.gres_gpu"].equals(pandas.Series(expected_gres_gpu))
+    assert frame["allocated.gres_gpu"].equals(
+        pandas.Series(expected_gres_gpu, dtype=float)
+    )
     assert frame["allocated.gres_rgu"].equals(pandas.Series(expected_gres_rgu))
     assert frame["allocated.gpu_type_rgu"].equals(pandas.Series(expected_gpu_type_rgu))
 


### PR DESCRIPTION
Small fix: remove a deprecation warning from Pandas about dtype incompatibility.