### PR TITLE
update automatic tasks scheduled time

### DIFF
--- a/scripts/systemd/sarc_backup.timer
+++ b/scripts/systemd/sarc_backup.timer
@@ -4,7 +4,7 @@ Requires=sarc_backup.service
 
 [Timer]
 Unit=sarc_backup.service
-OnCalendar=*-*-* 00:00:00
+OnCalendar=*-*-* 08:00:00
 
 [Install]
 WantedBy=timers.target

--- a/scripts/systemd/sarc_scrapers.timer
+++ b/scripts/systemd/sarc_scrapers.timer
@@ -4,7 +4,7 @@ Requires=sarc_scrapers.service
 
 [Timer]
 Unit=sarc_scrapers.service
-OnCalendar=*-*-* 00:00:00
+OnCalendar=*-*-* 03:30:00
 
 [Install]
 WantedBy=timers.target


### PR DESCRIPTION
The daily scraping time is moved from midnight to 3:30 am, so that even the 3 hours lag between BC and QC cannot introduce problems of time overlap. This is a temporary fix until a more proper way to deal with local times.