### PR TITLE
[hotfix] fix error "TypeError: can't subtract offset-naive and offset…

### DIFF
--- a/sarc/cli/acquire/jobs.py
+++ b/sarc/cli/acquire/jobs.py
@@ -45,7 +45,7 @@ def _daterange(start_date: datetime, end_date: datetime) -> Generator[datetime]:
 def _dates_auto(cluster_name: str) -> Iterable[datetime]:
     # we want to get the list of dates from the last valid date+1 in the database, until yesterday
     start = _dates_auto_first_date(cluster_name)
-    end = datetime.today()
+    end = datetime.today().replace(tzinfo=TZLOCAL)
     return _daterange(start, end)
 
 


### PR DESCRIPTION
this hotfix addresses a timedate comparisons error during jobs scraping:
"ERROR::sarc.cli.acquire.jobs::Error while acquiring data on tamia: TypeError: can't subtract offset-naive and offset-aware datetimes ; skipping cluster."

the problem was introduced with the commit https://github.com/mila-iqia/SARC/commit/83829bf6af9a774a7492b213a6821169dbb14b37