### PR TITLE
Implementation and tests of SarcClient

### DIFF
--- a/sarc/api/v0.py
+++ b/sarc/api/v0.py
@@ -62,10 +62,10 @@ def session_dep() -> Generator[Session]:
 
 def hascap(cap):
     async def check(request: Request, cfg: Config = Depends(config_dep)):
-        if not cfg.api.auth:
+        if not cfg.server.auth:
             yield "__admin__"
         else:
-            async for name in cfg.api.auth.get_email_capability(cap)(request):
+            async for name in cfg.server.auth.get_email_capability(cap)(request):
                 yield name
 
     return check
@@ -84,7 +84,7 @@ class Requestor:
 def is_admin(
     user: Annotated[str, Depends(can_query)], cfg: Config = Depends(config_dep)
 ) -> bool:
-    auth = cfg.api.auth
+    auth = cfg.server.auth
     if not auth:
         return True
     admin: Capability = deserialize(auth.capabilities.captype, "admin")
@@ -368,7 +368,7 @@ def get_job(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Job not found"
         )
-    return job_convert(job, extra_fields)
+    return job_convert(job, set(extra_fields.split(",")) if extra_fields else set())
 
 
 @router.get("/cluster/list", dependencies=[Depends(requestor)])

--- a/sarc/config.py
+++ b/sarc/config.py
@@ -245,29 +245,19 @@ class UserScrapingConfig:
 
 
 @dataclass
-class ApiConfig:
+class ServerConfig:
     """
-    Configuration for Python REST API client
-
-    Used if client is initialized without parameters.
-    Currently necessary for high-level Python client functions
-    such as `load_job_series()`, which internally initialize
-    a client without parameters.
+    Configuration for Python REST server
     """
 
-    url: str | None = None  # REST API URL (including port)
-    timeout: int = 120
-    # Default pagination size
-    per_page: int = 100
-    # Maximum page size
-    max_page_size: int = 5000
+    # Authentication manager
     auth: OAuthManager | None = None
 
 
 @dataclass
 class ClientConfig:
     db: DbConfig
-    api: ApiConfig = field(default_factory=ApiConfig)
+    server: ServerConfig = field(default_factory=ServerConfig)
     cache: Path | None = None
     loki: LokiConfig | None = None
     tempo: TempoConfig | None = None

--- a/sarc/rest/__init__.py
+++ b/sarc/rest/__init__.py
@@ -1,0 +1,7 @@
+import gifnoc
+
+from .client import SarcClient
+
+default_client = gifnoc.define("sarc.client", SarcClient)
+
+__all__ = [SarcClient]

--- a/sarc/rest/client.py
+++ b/sarc/rest/client.py
@@ -1,592 +1,247 @@
-"""
-Python client for SARC REST API.
+from __future__ import annotations
 
-Contains a SarcApiClient class for direct calls to REST API,
-and high-level client functions using REST API as backend,
-with almost same signatures as MongoDB counterparts:
-- count_jobs
-- get_job
-- get_jobs
-- get_rgus
-- get_users
-- load_job_series
-
-To use high-level functions, consider setting `api` section
-in SARC client config file, then calling your script
-in client mode with your config file.
-
-Example:
-    sarc-client.yaml
-        api:
-            url: http://api.sarc.com:1234
-    myscript.py
-        >>> from sarc.rest.client import count_jobs
-        >>> print(count_jobs())
-    run:
-        SARC_MODE=client SARC_CONFIG=sarc-client.yaml uv run myscript.py
-"""
-
+import os
+from collections.abc import Iterator
+from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Any, Callable, Iterable
+from pathlib import Path
+from typing import Any, Literal
 
 import httpx
+from serieux import deserialize
+from serieux.features.encrypt import EncryptionKey, Secret
+from serieux.formats import FileSource
 
-# This should be a proper neutral interface, currently it is dependent on DB types
-from sarc.client.series import AbstractJobSeriesFactory
-from sarc.config import UTC, ConfigurationError, config
-from sarc.models.api import SlurmJob, SlurmJobList, User, UserList
-from sarc.models.job import SlurmState
-from sarc.models.user import MemberType
-from sarc.traces import trace_decorator
-
-# TODO add methods here and to the API to fetch the missing user data
-# or figure out a way to send it that isn't too convoluted
-# Perhaps a UserProxy class of some sort would be the way
+from sarc.models.api import SlurmJobList, UserList
+from sarc.models.cluster import SlurmCluster
+from sarc.models.job import SlurmJob, SlurmState
+from sarc.models.user import MemberType, User
 
 
-class SarcApiClient:
-    """
-    Python client for SARC REST API.
+@dataclass(kw_only=True)
+class SarcClient:
+    # Base URL for SARC's API
+    base_url: str = "https://sarc.mila.quebec/v0"
 
-     If initialized without parameters, will look for
-     section `api` from SARC config file to get API URL.
-    """
+    # API token
+    token: Secret[str] | None = None
 
-    def __init__(
-        self,
-        remote_url: str | None = None,
-        oauth2_token: str | None = None,
-        timeout: int | None = None,
-        session: httpx.Client | None = None,
-        per_page: int | None = None,
-    ) -> None:
+    # Connection timeout in seconds
+    timeout: int = 120
+
+    # Optional httpx.Client instance to use for requests
+    session: httpx.Client | None = None
+
+    # How many results to get in one go
+    block_size: int = 100
+
+    # Extra fields to fetch on jobs
+    job_extra_fields: list[Literal["cluster_name", "sarc_user", "statistics"]] = field(
+        default_factory=list
+    )
+
+    @classmethod
+    def load(cls, config_file: str | Path | None = None):
+        """Load a client from a configuration file.
+
+        * No argument: load from sarc.client in the main configuration file
+        * load("file.yaml") => load from that file
+        * load("pyproject.toml:sarc") => load from that file's sarc field
         """
-        Initialize.
+        if config_file is None:
+            from . import default_client
 
-        :param remote_url: API URL
-        :param oauth2_token: Authentification token obtained from google.  Will do an interactive prompt if not specified
-        :param timeout: requests timeout, in seconds. Default: 120.
-        :param session: internal httpx client to use. Default: httpx module.
-        :param per_page: default page size for paginated endpoints. Default: 100.
-        """
+            return default_client._obj()
+        else:
+            if isinstance(config_file, str):
+                config_file = deserialize(FileSource, config_file)
+            return deserialize(
+                cls, config_file, EncryptionKey(os.getenv("SERIEUX_PASSWORD"))
+            )
 
-        api_cfg = config().api
+    def _extra_fields(self, extra_fields: list[str] | None) -> list[str] | None:
+        merged = list({*self.job_extra_fields, *(extra_fields or [])})
+        return merged or None
 
-        if remote_url is None:
-            if api_cfg.url is None:
-                raise ConfigurationError(
-                    "Remote URL not configured for REST API. "
-                    "Either pass URL to SarcApiClient object, "
-                    "or set `api` section in SARC config file"
-                )
-            remote_url = api_cfg.url
-
-        if timeout is None:
-            timeout = api_cfg.timeout
-
-        if per_page is None:
-            per_page = api_cfg.per_page
-
-        assert oauth2_token is not None
-
-        # Ensure no trailing slash for consistency
-        self.remote_url = remote_url.rstrip("/")
-        self.timeout = timeout
-        self.session = session or httpx
-        self.per_page = per_page
-        self.oauth2_token = oauth2_token
-
-    def _get(self, endpoint: str, params: dict | None = None) -> httpx.Response:
-        """Helper to perform a GET request."""
-        # Clean up params: remove None values and convert non-primitive types if needed
-        cleaned_params: dict[str, Any] = {}
-        if params:
-            for k, v in params.items():
-                if v is not None:
-                    if isinstance(v, datetime):
-                        cleaned_params[k] = v.isoformat()
-                    elif isinstance(v, list) and not v:
-                        # Force empty parameter.
-                        # This is to handle particular case of
-                        # empty list passed to `job_id`.
-                        cleaned_params[k] = ""
-                    else:
-                        cleaned_params[k] = v
-
-        url = f"{self.remote_url}{endpoint}"
-        response = self.session.get(
-            url,
-            params=cleaned_params,
-            timeout=self.timeout,
-            headers={"Authorization": f"Bearer {self.oauth2_token}"},
-        )
+    def _get(self, path: str, params: list[tuple[str, Any]] | None = None) -> Any:
+        headers = {}
+        if self.token is not None:
+            headers["Authorization"] = f"Bearer {self.token}"
+        url = self.base_url.rstrip("/") + "/" + path.lstrip("/")
+        getter = self.session.get if self.session is not None else httpx.get
+        response = getter(url, params=params, headers=headers, timeout=self.timeout)
         response.raise_for_status()
-        return response
-
-    # --- Job Endpoints ---
-
-    def job_query(
-        self,
-        cluster: str | None = None,
-        job_id: int | list[int] | None = None,
-        job_state: SlurmState | None = None,
-        username: str | None = None,
-        start: datetime | None = None,
-        end: datetime | None = None,
-    ) -> list[str]:
-        """
-        Query jobs.
-        Return a list of job internal object IDs,
-        which can be passed to job/id/{id}
-        """
-        params = {
-            "cluster": cluster,
-            "job_id": job_id,
-            "job_state": job_state.value if job_state else None,
-            "username": username,
-            "start": start,
-            "end": end,
-        }
-        response = self._get("/v0/job/query", params=params)
-        # The API returns list[PydanticObjectId], which serializes to list[str] in JSON
         return response.json()
 
-    def job_list(
+    def _job_params(
         self,
-        cluster: str | None = None,
-        job_id: int | list[int] | None = None,
-        job_state: SlurmState | None = None,
-        username: str | None = None,
+        cluster_name: str | None = None,
+        job_id: list[int] | None = None,
+        job_state: SlurmState | str | None = None,
+        email: str | None = None,
+        sarc_user_id: int | None = None,
+        cluster_user: str | None = None,
         start: datetime | None = None,
         end: datetime | None = None,
-        page: int = 1,
-        per_page: int | None = None,
-    ) -> SlurmJobList:
-        """
-        Query jobs with pagination.
-        Return a SlurmJobList result, containing
-        a paginated list of SlurmJob objects.
-        """
-        params = {
-            "cluster": cluster,
-            "job_id": job_id,
-            "job_state": job_state.value if job_state else None,
-            "username": username,
-            "start": start,
-            "end": end,
-            "page": page,
-            "per_page": per_page if per_page is not None else self.per_page,
-        }
-        response = self._get("/v0/job/list", params=params)
-        return SlurmJobList.model_validate(response.json())
+        extra_fields: list[str] | None = None,
+    ) -> list[tuple[str, Any]]:
+        params: list[tuple[str, Any]] = []
+        if cluster_name is not None:
+            params.append(("cluster_name", cluster_name))
+        if job_id is not None:
+            if len(job_id) == 0:
+                params.append(("job_id", ""))
+            else:
+                params.extend(("job_id", jid) for jid in job_id)
+        if job_state is not None:
+            params.append(
+                (
+                    "job_state",
+                    job_state if isinstance(job_state, str) else job_state.value,
+                )
+            )
+        if email is not None:
+            params.append(("email", email))
+        if sarc_user_id is not None:
+            params.append(("sarc_user_id", sarc_user_id))
+        if cluster_user is not None:
+            params.append(("cluster_user", cluster_user))
+        if start is not None:
+            params.append(("start", start.isoformat()))
+        if end is not None:
+            params.append(("end", end.isoformat()))
+        if extra_fields:
+            params.append(("extra_fields", ",".join(extra_fields)))
+        return params
 
-    def job_count(
+    def get_jobs(
         self,
-        cluster: str | None = None,
-        job_id: int | list[int] | None = None,
-        job_state: SlurmState | None = None,
-        username: str | None = None,
+        *,
+        cluster_name: str | None = None,
+        job_id: list[int] | None = None,
+        job_state: SlurmState | str | None = None,
+        email: str | None = None,
+        sarc_user_id: int | None = None,
+        cluster_user: str | None = None,
+        start: datetime | None = None,
+        end: datetime | None = None,
+        extra_fields: list[str] | None = None,
+    ) -> Iterator[SlurmJob]:
+        base_params = self._job_params(
+            cluster_name=cluster_name,
+            job_id=job_id,
+            job_state=job_state,
+            email=email,
+            sarc_user_id=sarc_user_id,
+            cluster_user=cluster_user,
+            start=start,
+            end=end,
+            extra_fields=self._extra_fields(extra_fields),
+        )
+        cursor = None
+        while cursor is not False:
+            params = base_params + [("limit", self.block_size)]
+            if cursor is not None:
+                params.append(("cursor", cursor))
+            page = SlurmJobList.model_validate(self._get("/job/query", params))
+            yield from page.results
+            cursor = page.cursor
+
+    def count_jobs(
+        self,
+        *,
+        cluster_name: str | None = None,
+        job_id: list[int] | None = None,
+        job_state: SlurmState | str | None = None,
+        email: str | None = None,
+        sarc_user_id: int | None = None,
+        cluster_user: str | None = None,
         start: datetime | None = None,
         end: datetime | None = None,
     ) -> int:
-        """Count jobs."""
-        params = {
-            "cluster": cluster,
-            "job_id": job_id,
-            "job_state": job_state.value if job_state else None,
-            "username": username,
-            "start": start,
-            "end": end,
-        }
-        response = self._get("/v0/job/count", params=params)
-        return response.json()
-
-    def job_by_id(self, id: int) -> SlurmJob:
-        """
-        Get a specific job by its internal ID.
-        """
-        response = self._get(f"/v0/job/id/{id}")
-        return SlurmJob.model_validate(response.json())
-
-    # --- Cluster Endpoints ---
-
-    def cluster_list(self) -> list[str]:
-        """
-        Return the names of available clusters.
-        """
-        response = self._get("/v0/cluster/list")
-        return response.json()
-
-    # --- GPU Endpoints ---
-
-    def gpu_rgu(self) -> dict[str, float]:
-        """
-        Return the mapping GPU->RGU.
-        """
-        response = self._get("/v0/gpu/rgu")
-        return response.json()
-
-    # --- User Endpoints ---
-
-    def user_query(
-        self,
-        display_name: str | None = None,
-        email: str | None = None,
-        member_type: MemberType | None = None,
-        member_start: datetime | None = None,
-        member_end: datetime | None = None,
-        supervisor: int | None = None,
-        supervisor_start: datetime | None = None,
-        supervisor_end: datetime | None = None,
-        co_supervisor: int | None = None,
-        co_supervisor_start: datetime | None = None,
-        co_supervisor_end: datetime | None = None,
-    ) -> list[int]:
-        """
-        Search users. Return list of user UUIDs.
-        """
-        params = {
-            "display_name": display_name,
-            "email": email,
-            "member_type": member_type.value if member_type else None,
-            "member_start": member_start,
-            "member_end": member_end,
-            "supervisor": str(supervisor) if supervisor else None,
-            "supervisor_start": supervisor_start,
-            "supervisor_end": supervisor_end,
-            "co_supervisor": str(co_supervisor) if co_supervisor else None,
-            "co_supervisor_start": co_supervisor_start,
-            "co_supervisor_end": co_supervisor_end,
-        }
-        response = self._get("/v0/user/query", params=params)
-        return [response.json()]
-
-    def user_list(
-        self,
-        display_name: str | None = None,
-        email: str | None = None,
-        member_type: MemberType | None = None,
-        member_start: datetime | None = None,
-        member_end: datetime | None = None,
-        supervisor: int | None = None,
-        supervisor_start: datetime | None = None,
-        supervisor_end: datetime | None = None,
-        co_supervisor: int | None = None,
-        co_supervisor_start: datetime | None = None,
-        co_supervisor_end: datetime | None = None,
-        page: int = 1,
-        per_page: int | None = None,
-    ) -> UserList:
-        """
-        List users with details and pagination.
-        """
-        params = {
-            "display_name": display_name,
-            "email": email,
-            "member_type": member_type.value if member_type else None,
-            "member_start": member_start,
-            "member_end": member_end,
-            "supervisor": str(supervisor) if supervisor else None,
-            "supervisor_start": supervisor_start,
-            "supervisor_end": supervisor_end,
-            "co_supervisor": str(co_supervisor) if co_supervisor else None,
-            "co_supervisor_start": co_supervisor_start,
-            "co_supervisor_end": co_supervisor_end,
-            "page": page,
-            "per_page": per_page if per_page is not None else self.per_page,
-        }
-        response = self._get("/v0/user/list", params=params)
-        return UserList.model_validate(response.json())
-
-    def user_by_id(self, id: int) -> User:
-        """
-        Get user with given ID.
-        """
-        response = self._get(f"/v0/user/id/{id}")
-        return User.model_validate(response.json())
-
-    def user_by_email(self, email: str) -> User:
-        """
-        Get user with given email.
-        """
-        response = self._get(f"/v0/user/email/{email}")
-        return User.model_validate(response.json())
-
-
-def _parse_common_args(
-    job_id: int | list[int] | None = None,
-    job_state: str | SlurmState | None = None,
-    start: str | datetime | None = None,
-    end: str | datetime | None = None,
-) -> tuple[list[int] | None, SlurmState | None, datetime | None, datetime | None]:
-    """
-    Helper to parse arguments common to job functions.
-    Used in high-level functions below.
-    """
-    if isinstance(job_id, int):
-        job_id = [job_id]
-
-    if isinstance(job_state, str):
-        job_state = SlurmState(job_state)
-
-    if isinstance(start, str):
-        start = datetime.strptime(start, "%Y-%m-%d").astimezone()
-    if isinstance(end, str):
-        end = datetime.strptime(end, "%Y-%m-%d").astimezone()
-
-    if start is not None:
-        start = start.astimezone(UTC)
-    if end is not None:
-        end = end.astimezone(UTC)
-
-    return job_id, job_state, start, end
-
-
-def count_jobs(
-    *,
-    cluster: str | None = None,
-    job_id: int | list[int] | None = None,
-    job_state: str | SlurmState | None = None,
-    user: str | None = None,
-    start: str | datetime | None = None,
-    end: str | datetime | None = None,
-) -> int:
-    """
-    Count jobs matching the criteria using the REST API.
-
-    Same signature as in `sarc.client.job.count_jobs`,
-    except parameter `query_options` which is specific to MongoDB.
-    """
-    job_id, job_state, start, end = _parse_common_args(job_id, job_state, start, end)
-
-    try:
-        return SarcApiClient().job_count(
-            cluster=cluster,
-            job_id=job_id,  # type: ignore
-            job_state=job_state,
-            username=user,
-            start=start,
-            end=end,
-        )
-    except httpx.HTTPStatusError as exc:
-        if exc.response.status_code != 404:
-            raise exc
-
-    return 0
-
-
-def get_job(**kwargs) -> SlurmJob | None:
-    """
-    Get a single job that matches the query, or None if nothing is found.
-
-    Same signature as `sarc.client.job.get_job` (except query_options).
-    """
-    # Extract arguments expected by list_jobs
-    cluster = kwargs.get("cluster")
-    user = kwargs.get("user")
-
-    job_id, job_state, start, end = _parse_common_args(
-        kwargs.get("job_id"),
-        kwargs.get("job_state"),
-        kwargs.get("start"),
-        kwargs.get("end"),
-    )
-
-    try:
-        # We fetch page 1 with page size 1.
-        # NB: the API sorts by submit_time desc by default, which
-        # returns the most recent version.
-        job_list_resp = SarcApiClient().job_list(
-            cluster=cluster,
-            job_id=job_id,  # type: ignore
-            job_state=job_state,
-            username=user,
-            start=start,
-            end=end,
-            page=1,
-            per_page=1,
-        )
-
-        if job_list_resp.jobs:
-            return job_list_resp.jobs[0]
-
-    except httpx.HTTPStatusError as exc:
-        if exc.response.status_code != 404:
-            raise exc
-
-    return None
-
-
-def get_jobs(
-    *,
-    cluster: str | None = None,
-    job_id: int | list[int] | None = None,
-    job_state: str | SlurmState | None = None,
-    user: str | None = None,
-    start: str | datetime | None = None,
-    end: str | datetime | None = None,
-) -> Iterable[SlurmJob]:
-    """
-    Get jobs matching the criteria using the REST API.
-    Fetches all results by iterating over pages.
-
-    Same signature as in `sarc.client.job.get_jobs`,
-    except parameter `query_options` which is specific to MongoDB,
-    """
-    # Use a single httpx client for all calls.
-    with httpx.Client() as session:
-        client = SarcApiClient(session=session)
-
-        per_page = client.per_page
-
-        job_id, job_state, start, end = _parse_common_args(
-            job_id, job_state, start, end
-        )
-
-        nb_all_jobs = 0
-        page = 1
-
-        try:
-            while True:
-                job_list_resp = client.job_list(
-                    cluster=cluster,
-                    job_id=job_id,  # type: ignore
-                    job_state=job_state,  # type: ignore
-                    username=user,
-                    start=start,
-                    end=end,
-                    page=page,
-                    per_page=per_page,
-                )
-
-                for job in job_list_resp.jobs:
-                    yield job
-
-                nb_all_jobs += len(job_list_resp.jobs)
-
-                # Check if we have fetched everything
-                if nb_all_jobs >= job_list_resp.total:
-                    break
-
-                # Or if the current page returned fewer than per_page (last page)
-                if len(job_list_resp.jobs) < job_list_resp.per_page:
-                    break
-
-                page += 1
-
-        except httpx.HTTPStatusError as exc:
-            if exc.response.status_code != 404:
-                raise exc
-
-
-def get_rgus(rgu_version: str = "1.0") -> dict[str, float]:
-    """
-    Return GPU->RGU mapping.
-
-    Note: rgu_version argument is ignored as the API does not currently support it.
-    """
-    if rgu_version != "1.0":
-        raise NotImplementedError("rgu_version != 1.0 is not yet supported by REST API")
-    return SarcApiClient().gpu_rgu()
-
-
-def get_users(
-    display_name: str | None = None,
-    email: str | None = None,
-    member_type: MemberType | None = None,
-    member_start: datetime | None = None,
-    member_end: datetime | None = None,
-    supervisor: int | None = None,
-    supervisor_start: datetime | None = None,
-    supervisor_end: datetime | None = None,
-    co_supervisor: int | None = None,
-    co_supervisor_start: datetime | None = None,
-    co_supervisor_end: datetime | None = None,
-) -> list[User]:
-    """
-    Get users matching the criteria using the REST API.
-    Fetches all results by iterating over pages.
-
-    **NB**: Not same signature as sarc.users.db.get_users,
-    which waits for a MongoDB `query` dict.
-    """
-    with httpx.Client() as session:
-        client = SarcApiClient(session=session)
-
-        per_page = client.per_page
-
-        all_users = []
-        page = 1
-
-        while True:
-            user_list_resp = client.user_list(
-                display_name=display_name,
+        return self._get(
+            "/job/count",
+            self._job_params(
+                cluster_name=cluster_name,
+                job_id=job_id,
+                job_state=job_state,
                 email=email,
-                member_type=member_type,
-                member_start=member_start,
-                member_end=member_end,
-                supervisor=supervisor,
-                supervisor_start=supervisor_start,
-                supervisor_end=supervisor_end,
-                co_supervisor=co_supervisor,
-                co_supervisor_start=co_supervisor_start,
-                co_supervisor_end=co_supervisor_end,
-                page=page,
-                per_page=per_page,
-            )
-
-            all_users.extend(user_list_resp.users)
-
-            if len(all_users) >= user_list_resp.total:
-                break
-
-            if len(user_list_resp.users) < user_list_resp.per_page:
-                break
-
-            page += 1
-
-        return all_users
-
-
-class RestJobSeriesFactory(AbstractJobSeriesFactory):
-    """
-    Implementation of JobSeriesFactory for REST API.
-    Allow to implement load_job_series for REST API below.
-    """
-
-    def _get_desc(self) -> str:
-        return super()._get_desc() + " (REST)"
-
-    def count_jobs(self, *args, **kwargs) -> int:
-        return count_jobs(*args, **kwargs)
-
-    # TODO: Figure out a way to make this interface for maybe.  Or maybe add a dedicated method for load_job_series
-    def get_jobs(self, *args, **kwargs) -> Iterable[SlurmJob]:
-        return get_jobs(*args, **kwargs)
-
-    # TODO: this will not work because User doesn't have all the ValidFields
-    def get_users(self) -> list[User]:
-        return get_users()
-
-
-@trace_decorator()
-def load_job_series(
-    *,
-    fields: None | list[str] | dict[str, str] = None,
-    clip_time: bool = False,
-    callback: None | Callable = None,
-    **jobs_args,
-) -> Any:  # Returns DataFrame, Any to avoid import
-    """
-    Query jobs using the REST API and return them in a DataFrame.
-
-    See sarc.client.series.JobSeriesFactory.load_job_series for details.
-    """
-    factory = RestJobSeriesFactory()
-    try:
-        return factory.load_job_series(
-            fields=fields, clip_time=clip_time, callback=callback, **jobs_args
+                sarc_user_id=sarc_user_id,
+                cluster_user=cluster_user,
+                start=start,
+                end=end,
+            ),
         )
-    except httpx.HTTPStatusError as exc:
-        resp = exc.response.json()
-        raise RuntimeError(resp) from exc
+
+    def get_job(self, id: int, extra_fields: list[str] | None = None) -> SlurmJob:
+        merged = self._extra_fields(extra_fields)
+        params = [("extra_fields", ",".join(merged))] if merged else None
+        return SlurmJob.model_validate(self._get(f"/job/id/{id}", params))
+
+    def _user_params(
+        self,
+        display_name: str | None = None,
+        email: str | None = None,
+        start: datetime | None = None,
+        end: datetime | None = None,
+        member_type: MemberType | str | None = None,
+        supervisor: int | None = None,
+    ) -> list[tuple[str, Any]]:
+        params: list[tuple[str, Any]] = []
+        if display_name is not None:
+            params.append(("display_name", display_name))
+        if email is not None:
+            params.append(("email", email))
+        if start is not None:
+            params.append(("start", start.isoformat()))
+        if end is not None:
+            params.append(("end", end.isoformat()))
+        if member_type is not None:
+            params.append(
+                (
+                    "member_type",
+                    member_type if isinstance(member_type, str) else member_type.value,
+                )
+            )
+        if supervisor is not None:
+            params.append(("supervisor", supervisor))
+        return params
+
+    def get_users(
+        self,
+        *,
+        display_name: str | None = None,
+        email: str | None = None,
+        start: datetime | None = None,
+        end: datetime | None = None,
+        member_type: MemberType | str | None = None,
+        supervisor: int | None = None,
+    ) -> Iterator[User]:
+        base_params = self._user_params(
+            display_name=display_name,
+            email=email,
+            start=start,
+            end=end,
+            member_type=member_type,
+            supervisor=supervisor,
+        )
+        cursor = None
+        while cursor is not False:
+            params = base_params + [("limit", self.block_size)]
+            if cursor is not None:
+                params.append(("cursor", cursor))
+            page = UserList.model_validate(self._get("/user/query", params))
+            yield from page.results
+            cursor = page.cursor
+
+    def get_user_by_id(self, id: int) -> User:
+        return User.model_validate(self._get(f"/user/id/{id}"))
+
+    def get_user_by_email(self, email: str) -> User:
+        return User.model_validate(self._get(f"/user/email/{email}"))
+
+    def get_clusters(self) -> list[SlurmCluster]:
+        return [SlurmCluster.model_validate(c) for c in self._get("/cluster/list")]
+
+    def get_rgus(self) -> dict[str, float]:
+        return self._get("/gpu/rgu")

--- a/tests/functional/api/conftest.py
+++ b/tests/functional/api/conftest.py
@@ -8,7 +8,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from sarc.config import config
-from sarc.rest.client import SarcApiClient
+from sarc.rest.client import SarcClient
 
 
 @pytest.fixture(scope="session")
@@ -123,35 +123,7 @@ def client(app, oauth_mock):
 
 @pytest.fixture
 def sarc_client(app, oauth_mock):
-    """
-    Returns a SarcApiClient that uses the FastAPI TestClient session.
-    The 'client' fixture comes from tests/functional/api/conftest.py
-    and is connected to the app with the database fixtures active.
-
-    Used to test low-level SarcApiClient methods.
-    """
+    """Returns a SarcClient backed by the FastAPI TestClient."""
     mc = ModifiedTestClient(app, oauth_mock)
-    return SarcApiClient(
-        remote_url="", session=mc, oauth2_token=mc.get_token("admin@admin.admin")
-    )
-
-
-@pytest.fixture
-def mock_client_class(app, oauth_mock, monkeypatch):
-    """
-    Replace SarcApiClient class with a mock class
-    that uses the FastAPI TestClient session.
-
-    Used to test high-level REST client functions.
-    """
-    mc = ModifiedTestClient(app, oauth_mock)
-
-    class MockSarcApiClient(SarcApiClient):
-        def __init__(self, *args, **kwargs):
-            super().__init__(
-                remote_url="",
-                session=mc,
-                oauth2_token=mc.get_token("admin@admin.admin"),
-            )
-
-    monkeypatch.setattr("sarc.rest.client.SarcApiClient", MockSarcApiClient)
+    mc.set_email("admin@admin.admin")
+    return SarcClient(base_url="/v0", session=mc, token=mc.token)

--- a/tests/functional/api/conftest.py
+++ b/tests/functional/api/conftest.py
@@ -38,17 +38,17 @@ def app(oauth_mock, oauth_port):
         return mc
 
     oauth_overrides = {
-        "sarc.api.auth.server_metadata_url": f"http://127.0.0.1:{oauth_port}/.well-known/openid-configuration"
+        "sarc.server.auth.server_metadata_url": f"http://127.0.0.1:{oauth_port}/.well-known/openid-configuration"
     }
 
     with gifnoc.overlay(oauth_overrides):
         app = FastAPI()
         app.client = client
         app.include_router(router)
-        api_config = config().api
-        assert api_config is not None
-        if api_config.auth is not None:
-            api_config.auth.install(app)
+        server_config = config().server
+        assert server_config is not None
+        if server_config.auth is not None:
+            server_config.auth.install(app)
 
         yield app
 

--- a/tests/functional/api/test_rest_client.py
+++ b/tests/functional/api/test_rest_client.py
@@ -1,770 +1,240 @@
-from datetime import datetime, timedelta
-from unittest.mock import patch
-from uuid import UUID
-
 import httpx
 import pytest
-from pydantic_mongo import PydanticObjectId
 
-from sarc.client.job import SlurmJob, SlurmState
-from sarc.config import UTC, ConfigurationError, config
-from sarc.core.models.users import MemberType
-from sarc.rest.client import SarcApiClient
 from tests.common.dateutils import _iso_mtl_dt
-
-# Test SarcApiClient Initialization
-
-
-def test_init_with_params():
-    c = SarcApiClient(remote_url="http://example.com", timeout=60, oauth2_token="")
-    assert c.remote_url == "http://example.com"
-    assert c.timeout == 60
-    assert c.per_page == config().api.per_page
-
-    c2 = SarcApiClient("http://example.com/", per_page=12, oauth2_token="")
-    assert c2.remote_url == "http://example.com"
-    assert c2.timeout == 120  # default timeout
-    assert c2.per_page == 12
-
-
-def test_init_from_config():
-    # We patch sarc.rest.client.config so we don't mess with the global app config
-    with patch("sarc.rest.client.config") as mock_config:
-        mock_config.return_value.api.url = "http://config-url.com/"
-        mock_config.return_value.api.timeout = 90
-        mock_config.return_value.api.per_page = 904
-
-        c = SarcApiClient(oauth2_token="")
-        assert c.remote_url == "http://config-url.com"
-        assert c.timeout == 90
-        assert c.per_page == 904
-
-
-def test_init_no_config_raises_error():
-    with pytest.raises(ConfigurationError):
-        SarcApiClient()
-
-
-# Test SarcApiClient Methods
-
-
-@pytest.mark.usefixtures("read_only_db", "client_mode")
-def test_get_job_not_found_pydantic_id(sarc_client):
-    # Generate a random ObjectId that shouldn't exist
-    oid = str(PydanticObjectId())
-
-    with pytest.raises(httpx.HTTPStatusError) as excinfo:
-        sarc_client.job_by_id(oid)
-    assert excinfo.value.response.status_code == 404
-    assert "Job not found" in excinfo.value.response.json()["detail"]
-
-
-@pytest.mark.usefixtures("read_only_db_with_users")
-def test_get_jobs_by_cluster(sarc_client):
-    data = sarc_client.job_query(cluster="raisin")
-    assert len(data) > 0
-    for jid in data:
-        job = sarc_client.job_by_id(jid)
-        assert job.cluster_name == "raisin"
-
-
-@pytest.mark.usefixtures("read_only_db")
-def test_get_jobs_by_job_id(sarc_client):
-    data = sarc_client.job_query(job_id=10)
-    assert len(data) > 0
-    for jid in data:
-        job = sarc_client.job_by_id(jid)
-        assert job.job_id == 10
-
-
-@pytest.mark.usefixtures("read_only_db")
-def test_get_jobs_by_user(sarc_client):
-    # Corresponds to test_get_jobs_by_user in test_v0
-    data = sarc_client.job_query(username="petitbonhomme")
-    assert len(data) > 0
-    for jid in data:
-        job = sarc_client.job_by_id(jid)
-        assert job.user == "petitbonhomme"
-
-
-@pytest.mark.usefixtures("read_only_db_with_users")
-def test_get_jobs_by_state(sarc_client):
-    # Corresponds to test_get_jobs_by_state in test_v0
-    data = sarc_client.job_query(job_state=SlurmState.COMPLETED)
-    assert len(data) > 0
-    for jid in data:
-        job = sarc_client.job_by_id(jid)
-        assert job.job_state == SlurmState.COMPLETED
-
-
-@pytest.mark.usefixtures("read_only_db")
-def test_get_jobs_empty_result(sarc_client):
-    # Corresponds to test_get_jobs_empty_result in test_v0
-    # Use a very high job ID that doesn't exist
-    data = sarc_client.job_query(job_id=9999999999)
-    assert len(data) == 0
-
-
-@pytest.mark.usefixtures("read_only_db")
-def test_get_jobs_invalid_cluster(sarc_client):
-    # Corresponds to test_get_jobs_invalid_cluster in test_v0
-    with pytest.raises(httpx.HTTPStatusError) as excinfo:
-        sarc_client.job_query(cluster="invalid_cluster")
-    assert excinfo.value.response.status_code == 404
-    assert (
-        "No such cluster 'invalid_cluster'" in excinfo.value.response.json()["detail"]
-    )
-
-
-def test_get_jobs_invalid_job_state(sarc_client):
-    with pytest.raises(AttributeError):
-        sarc_client.job_query(job_state="INVALID")
-
-
-@pytest.mark.usefixtures("read_only_db")
-def test_get_jobs_with_naive_datetime_filters(sarc_client):
-    with pytest.raises(httpx.HTTPStatusError) as excinfo:
-        sarc_client.job_query(
-            start=datetime.fromisoformat("2023-01-01T00:00:00"),
-            end=datetime.fromisoformat("2023-12-31T23:59:59"),
-        )
-    assert excinfo.value.response.status_code == 422
-    assert (
-        "Time-aware datetime required. E.g: 2025-01-01T10:00Z (UTC), 2025-01-01T05:00-05:00 (UTC-5 hours)"
-        in excinfo.value.response.text
-    )
-
-
-@pytest.mark.usefixtures("read_only_db")
-def test_get_jobs_with_datetime_filters(sarc_client):
-    data = sarc_client.job_query(
-        start=_iso_mtl_dt("2023-01-01T00:00:00"), end=_iso_mtl_dt("2023-12-31T23:59:59")
-    )
-    assert len(data) > 0
-
-
-@pytest.mark.usefixtures("read_only_db_with_users")
-def test_get_jobs_multiple_filters(sarc_client):
-    # Corresponds to test_get_jobs_multiple_filters
-    data = sarc_client.job_query(
-        cluster="raisin",
-        job_state=SlurmState.COMPLETED,
-        start=datetime(2023, 1, 1, tzinfo=UTC),
-    )
-    assert len(data) > 0
-    for jid in data:
-        job = sarc_client.job_by_id(jid)
-        assert job.cluster_name == "raisin"
-        assert job.job_state == SlurmState.COMPLETED
 
 
 @pytest.mark.usefixtures("read_only_db")
 def test_get_jobs_no_filters(sarc_client):
-    # Corresponds to test_get_jobs_no_filters
-    data = sarc_client.job_query()
-    assert len(data) == 24
-
-
-@pytest.mark.parametrize(
-    "params,expected",
-    [
-        (dict(cluster="raisin"), 20),
-        (dict(job_id=10), 1),
-        (dict(username="petitbonhomme"), 20),
-        (dict(job_state=SlurmState.COMPLETED), 1),
-        (dict(job_id=9999999999), 0),
-        (
-            dict(
-                start=_iso_mtl_dt("2023-01-01T00:00:00"),
-                end=_iso_mtl_dt("2023-02-15T23:59:59"),
-            ),
-            8,
-        ),
-        (
-            dict(
-                cluster="raisin",
-                job_state=SlurmState.COMPLETED,
-                start=_iso_mtl_dt("2023-01-01T00:00:00"),
-            ),
-            1,
-        ),
-        ({}, 24),
-    ],
-)
-@pytest.mark.usefixtures("read_only_db_with_users")
-def test_count_jobs(sarc_client, params, expected):
-    count = sarc_client.job_count(**params)
-    r_query = sarc_client.job_query(**params)
-    r_list = sarc_client.job_list(**params)
-    assert count == expected
-    assert len(r_query) == expected
-    assert len(r_list.jobs) == expected
+    jobs = list(sarc_client.get_jobs())
+    assert len(jobs) == 22
 
 
 @pytest.mark.usefixtures("read_only_db")
-def test_count_jobs_invalid_cluster(sarc_client):
-    with pytest.raises(httpx.HTTPStatusError) as excinfo:
-        sarc_client.job_count(cluster="invalid_cluster")
-    assert excinfo.value.response.status_code == 404
-    assert (
-        "No such cluster 'invalid_cluster'" in excinfo.value.response.json()["detail"]
+def test_get_jobs_by_cluster(sarc_client):
+    jobs = list(sarc_client.get_jobs(cluster_name="raisin"))
+    assert len(jobs) == 19
+    assert all(
+        j.cluster_name == "raisin" for j in jobs
+    )  # auto-populated when filtering by cluster
+
+
+@pytest.mark.usefixtures("read_only_db")
+def test_get_jobs_by_cluster_user(sarc_client):
+    jobs = list(sarc_client.get_jobs(cluster_user="beaubonhomme"))
+    assert len(jobs) == 1
+    assert jobs[0].cluster_user == "beaubonhomme"
+
+
+@pytest.mark.usefixtures("read_only_db")
+def test_get_jobs_by_email(sarc_client):
+    jobs = list(sarc_client.get_jobs(email="petitbonhomme@mila.quebec"))
+    assert len(jobs) == 21
+
+
+@pytest.mark.usefixtures("read_only_db")
+def test_get_jobs_by_sarc_user_id(sarc_client):
+    jobs = list(sarc_client.get_jobs(sarc_user_id=9))
+    assert len(jobs) == 21
+
+
+@pytest.mark.usefixtures("read_only_db")
+def test_get_jobs_by_job_id(sarc_client):
+    jobs = list(sarc_client.get_jobs(job_id=[10]))
+    assert len(jobs) == 1
+    assert jobs[0].job_id == 10
+
+
+@pytest.mark.usefixtures("read_only_db")
+def test_get_jobs_by_multiple_job_ids(sarc_client):
+    jobs = list(sarc_client.get_jobs(job_id=[10, 15]))
+    assert len(jobs) == 2
+
+
+@pytest.mark.usefixtures("read_only_db")
+def test_get_jobs_empty_job_id_list(sarc_client):
+    jobs = list(sarc_client.get_jobs(job_id=[]))
+    assert len(jobs) == 0
+
+
+@pytest.mark.usefixtures("read_only_db")
+def test_get_jobs_by_state(sarc_client):
+    jobs = list(sarc_client.get_jobs(job_state="COMPLETED"))
+    assert len(jobs) == 1
+    assert jobs[0].job_state == "COMPLETED"
+
+
+@pytest.mark.usefixtures("read_only_db")
+def test_get_jobs_with_datetime_filters(sarc_client):
+    jobs = list(
+        sarc_client.get_jobs(
+            start=_iso_mtl_dt("2023-01-01T00:00:00"),
+            end=_iso_mtl_dt("2023-12-31T23:59:59"),
+        )
     )
+    assert len(jobs) > 0
 
 
 @pytest.mark.usefixtures("read_only_db")
-def test_count_jobs_invalid_job_state(sarc_client):
-    with pytest.raises(AttributeError):
-        sarc_client.job_count(job_state="INVALID")
+def test_get_jobs_invalid_cluster(sarc_client):
+    with pytest.raises(httpx.HTTPStatusError) as exc:
+        list(sarc_client.get_jobs(cluster_name="invalid_cluster"))
+    assert exc.value.response.status_code == 404
 
 
-@pytest.mark.usefixtures("read_only_db_with_users")
-def test_cluster_list(sarc_client):
-    data = sarc_client.cluster_list()
-    for cluster_name in ("raisin", "fromage", "patate"):
-        assert cluster_name in data
+@pytest.mark.usefixtures("read_only_db")
+def test_get_jobs_pagination(sarc_client):
+    """Verify pagination works: block_size=5 should still return all 22 jobs."""
+    sarc_client.block_size = 5
+    jobs = list(sarc_client.get_jobs())
+    assert len(jobs) == 22
 
 
-def _gen_fake_rgus():
-    return {"A100": 3.21}
+@pytest.mark.usefixtures("read_only_db")
+def test_get_jobs_extra_fields(sarc_client):
+    jobs = list(
+        sarc_client.get_jobs(
+            cluster_user="beaubonhomme",
+            extra_fields=["cluster_name", "sarc_user", "statistics"],
+        )
+    )
+    assert len(jobs) == 1
+    assert jobs[0].cluster_name == "raisin"
+    assert jobs[0].sarc_user is not None
+    assert jobs[0].sarc_user.email == "beaubonhomme@mila.quebec"
+    assert isinstance(jobs[0].statistics, dict)
 
 
-@pytest.mark.usefixtures("read_only_db_with_users")
-def test_gpu_rgu(sarc_client, monkeypatch):
-    monkeypatch.setattr("sarc.api.v0.get_rgus", _gen_fake_rgus)
-
-    rgus = sarc_client.gpu_rgu()
-    assert rgus == _gen_fake_rgus()
+@pytest.mark.usefixtures("read_only_db")
+def test_count_jobs_no_filters(sarc_client):
+    assert sarc_client.count_jobs() == 22
 
 
-@pytest.mark.usefixtures("read_only_db_with_users")
-def test_user_query_by_display_name(sarc_client):
-    data = sarc_client.user_query(display_name="janE")
-    assert len(data) == 1
-    assert str(data[0]) == "1f9b04e5-0ec4-4577-9196-2b03d254e344"
+@pytest.mark.usefixtures("read_only_db")
+def test_count_jobs_by_cluster(sarc_client):
+    assert sarc_client.count_jobs(cluster_name="raisin") == 19
 
-    user = sarc_client.user_by_id(data[0])
-    assert user.display_name == "Jane Doe"
-    assert user.uuid == data[0]
+
+@pytest.mark.usefixtures("read_only_db")
+def test_count_jobs_by_cluster_user(sarc_client):
+    assert sarc_client.count_jobs(cluster_user="petitbonhomme") == 21
+
+
+@pytest.mark.usefixtures("read_only_db")
+def test_get_job_by_id(sarc_client):
+    job = sarc_client.get_job(1)
+    assert job.id == 1
+
+
+@pytest.mark.usefixtures("read_only_db")
+def test_get_job_by_id_not_found(sarc_client):
+    with pytest.raises(httpx.HTTPStatusError) as exc:
+        sarc_client.get_job(999_999)
+    assert exc.value.response.status_code == 404
+
+
+@pytest.mark.usefixtures("read_only_db")
+def test_get_job_with_extra_fields(sarc_client):
+    job = sarc_client.get_job(1, extra_fields=["cluster_name", "sarc_user"])
+    assert job.cluster_name is not None
+    assert job.sarc_user is not None
+
+
+@pytest.mark.usefixtures("read_only_db")
+def test_job_extra_fields_default(sarc_client):
+    """job_extra_fields on the client are applied to every get_jobs/get_job call."""
+    sarc_client.job_extra_fields = ["cluster_name", "sarc_user"]
+    (job,) = list(sarc_client.get_jobs(cluster_user="beaubonhomme"))
+    assert job.cluster_name == "raisin"
+    assert job.sarc_user is not None
+
+    job2 = sarc_client.get_job(job.id)
+    assert job2.cluster_name == "raisin"
+    assert job2.sarc_user is not None
+
+
+@pytest.mark.usefixtures("read_only_db")
+def test_job_extra_fields_merged(sarc_client):
+    """Per-call extra_fields are merged with the instance default."""
+    sarc_client.job_extra_fields = ["cluster_name"]
+    (job,) = list(
+        sarc_client.get_jobs(cluster_user="beaubonhomme", extra_fields=["sarc_user"])
+    )
+    assert job.cluster_name == "raisin"
+    assert job.sarc_user is not None
+
+
+@pytest.mark.usefixtures("read_only_db")
+def test_get_users_no_filters(sarc_client):
+    users = list(sarc_client.get_users())
+    assert len(users) == 10
+
+
+@pytest.mark.usefixtures("read_only_db")
+def test_get_users_by_display_name(sarc_client):
+    users = list(sarc_client.get_users(display_name="janE"))
+    assert len(users) == 1
+    assert users[0].display_name == "Jane Doe"
+
+
+@pytest.mark.usefixtures("read_only_db")
+def test_get_users_by_email(sarc_client):
+    users = list(sarc_client.get_users(email="bonhomme@mila.quebec"))
+    assert len(users) == 1
+    assert users[0].email == "bonhomme@mila.quebec"
+
+
+@pytest.mark.usefixtures("read_only_db")
+def test_get_users_empty_result(sarc_client):
+    users = list(sarc_client.get_users(email="nobody@nowhere.example"))
+    assert len(users) == 0
+
+
+@pytest.mark.usefixtures("read_only_db")
+def test_get_users_pagination(sarc_client):
+    """Verify pagination: block_size=3 should still return all users."""
+    sarc_client.block_size = 3
+    users = list(sarc_client.get_users())
+    assert len(users) == 10
+
+
+@pytest.mark.usefixtures("read_only_db")
+def test_get_user_by_id(sarc_client):
+    user = sarc_client.get_user_by_id(1)
+    assert user.id == 1
     assert user.email == "jdoe@example.com"
 
 
-@pytest.mark.usefixtures("read_only_db_with_users")
-def test_user_query_by_email(sarc_client):
-    data = sarc_client.user_query(email="bonhomme@mila.quebec")
-    assert isinstance(data, list)
-    assert len(data) == 1
-    assert str(data[0]) == "5a8b9e7f-afcc-4ced-b596-44fcdb3a0cff"
-
-    user = sarc_client.user_by_id(data[0])
-    assert user.display_name == "M/Ms Bonhomme"
-    assert user.uuid == data[0]
-    assert user.email == "bonhomme@mila.quebec"
+@pytest.mark.usefixtures("read_only_db")
+def test_get_user_by_id_not_found(sarc_client):
+    with pytest.raises(httpx.HTTPStatusError) as exc:
+        sarc_client.get_user_by_id(999_999)
+    assert exc.value.response.status_code == 404
 
 
-@pytest.mark.parametrize(
-    "date,expected",
-    [
-        # After 2026/05/01 and until 2027/09/01, there should be only 1 match
-        (datetime(2027, 9, 1, tzinfo=UTC), True),
-        (datetime(2027, 8, 20, tzinfo=UTC), True),
-        (datetime(2026, 5, 2, tzinfo=UTC), True),
-        # Before 2020/09/01 and after 2027/09/01, there should be not match
-        (datetime(2005, 8, 31, tzinfo=UTC), False),
-        (datetime(2010, 8, 31, tzinfo=UTC), False),
-        (datetime(2018, 8, 31, tzinfo=UTC), False),
-        (datetime(2020, 8, 31, 23, 59, 59, 999999, tzinfo=UTC), False),
-        (datetime(2027, 9, 1, 0, 0, 1, tzinfo=UTC), False),
-        (datetime(2027, 12, 1, tzinfo=UTC), False),
-        (datetime(2044, 7, 1, tzinfo=UTC), False),
-    ],
-)
-@pytest.mark.usefixtures("read_only_db_with_users")
-def test_user_query_by_member_type_professor_now(sarc_client, freezer, date, expected):
-    freezer.move_to(date)
-    data = sarc_client.user_query(member_type=MemberType.PROFESSOR)
-    assert isinstance(data, list)
-    data = [str(uuid) for uuid in data]
-    if expected:
-        assert len(data) == 1
-        assert sorted(data) == ["1f9b04e5-0ec4-4577-9196-2b03d254e344"]
-    else:
-        assert len(data) == 0
-
-
-@pytest.mark.parametrize(
-    "member_type,date,identifiers",
-    [
-        (
-            MemberType.PHD_STUDENT,
-            datetime(2020, 8, 31, 23, 59, 59, 999999, tzinfo=UTC),
-            ["7ecd3a8a-ab71-499e-b38a-ceacd91a99c4"],
-        ),
-        (
-            MemberType.STAFF,
-            datetime(2022, 5, 1, tzinfo=UTC),
-            ["8b4fef2b-8f47-4eb6-9992-3e7e1133b42a"],
-        ),
-    ],
-)
-@pytest.mark.usefixtures("read_only_db_with_users")
-def test_user_query_by_member_type_other_now(
-    sarc_client, freezer, member_type, date, identifiers
-):
-    freezer.move_to(date)
-    data = sarc_client.user_query(member_type=member_type)
-    assert isinstance(data, list)
-    assert sorted(str(uuid) for uuid in data) == sorted(identifiers)
-
-
-@pytest.mark.parametrize(
-    "start,nb_expected",
-    [
-        # Start old enough to get all supervised users (2 users)
-        (datetime(2005, 1, 1, tzinfo=UTC), 2),
-        (datetime(2018, 8, 31, 23, 59, 59, 999999, tzinfo=UTC), 2),
-        (datetime(2018, 9, 1, tzinfo=UTC), 2),
-        (datetime(2019, 9, 1, tzinfo=UTC), 2),
-        (datetime(2020, 9, 1, tzinfo=UTC), 2),
-        # From these start dates, we get only 1 supervised user
-        (datetime(2021, 5, 2, 0, 0, 0, 1, tzinfo=UTC), 1),
-        (datetime(2022, 1, 1, tzinfo=UTC), 1),
-        (datetime(2022, 10, 1, tzinfo=UTC), 1),
-        (datetime(2022, 5, 1, tzinfo=UTC), 1),
-        # From these start dates, there is no more user supervised by this prof.
-        (datetime(2023, 1, 1, 0, 0, 1, tzinfo=UTC), 0),
-        (datetime(2025, 1, 1, tzinfo=UTC), 0),
-        (datetime(2035, 1, 1, tzinfo=UTC), 0),
-    ],
-)
-@pytest.mark.usefixtures("read_only_db_with_users")
-def test_user_query_by_supervisor_start(sarc_client, start, nb_expected):
-    supervisor = UUID("1f9b04e5-0ec4-4577-9196-2b03d254e344")
-
-    data = sarc_client.user_query(supervisor=supervisor, supervisor_start=start)
-    assert isinstance(data, list)
-    assert len(data) == nb_expected
-    data = [str(uuid) for uuid in data]
-    if nb_expected == 2:
-        assert sorted(data) == [
-            "7ecd3a8a-ab71-499e-b38a-ceacd91a99c4",
-            "7ee5849c-241e-4d84-a4d2-1f73e22784f9",
-        ]
-    elif nb_expected == 1:
-        assert data == ["7ee5849c-241e-4d84-a4d2-1f73e22784f9"]
-    else:
-        assert not data
-
-
-@pytest.mark.parametrize(
-    "end,nb_expected",
-    [
-        # End new enough to get all supervised users (2 users)
-        (datetime(2035, 1, 1, tzinfo=UTC), 2),
-        (datetime(2025, 1, 1, tzinfo=UTC), 2),
-        (datetime(2023, 1, 1, tzinfo=UTC), 2),
-        (datetime(2022, 5, 1, tzinfo=UTC), 2),
-        (datetime(2022, 1, 1, tzinfo=UTC), 2),
-        # Until these end dates, we get only 1 supervised user
-        (datetime(2021, 5, 1, tzinfo=UTC), 1),
-        (datetime(2020, 1, 1, tzinfo=UTC), 1),
-        (datetime(2019, 1, 1, tzinfo=UTC), 1),
-        (datetime(2018, 9, 1, tzinfo=UTC), 1),
-        # Until these end dates, there is no more user supervised by this prof.
-        (datetime(2018, 8, 31, 23, 59, 59, 9999, tzinfo=UTC), 0),
-        (datetime(2017, 1, 1, tzinfo=UTC), 0),
-        (datetime(2005, 1, 1, tzinfo=UTC), 0),
-    ],
-)
-@pytest.mark.usefixtures("read_only_db_with_users")
-def test_user_query_by_supervisor_end(sarc_client, end, nb_expected):
-    supervisor = UUID("1f9b04e5-0ec4-4577-9196-2b03d254e344")
-    data = sarc_client.user_query(supervisor=supervisor, supervisor_end=end)
-    assert isinstance(data, list)
-    assert len(data) == nb_expected
-    data = [str(uuid) for uuid in data]
-    if nb_expected == 2:
-        assert sorted(data) == [
-            "7ecd3a8a-ab71-499e-b38a-ceacd91a99c4",
-            "7ee5849c-241e-4d84-a4d2-1f73e22784f9",
-        ]
-    elif nb_expected == 1:
-        assert data == ["7ecd3a8a-ab71-499e-b38a-ceacd91a99c4"]
-    else:
-        assert not data
-
-
-@pytest.mark.parametrize(
-    "start,end,expected",
-    [
-        (datetime(2022, 1, 1, tzinfo=UTC), datetime(2023, 1, 1, tzinfo=UTC), True),
-        (datetime(2022, 1, 1, tzinfo=UTC), datetime(2022, 5, 1, tzinfo=UTC), True),
-        (datetime(2022, 5, 1, tzinfo=UTC), datetime(2023, 1, 1, tzinfo=UTC), True),
-        (datetime(2022, 5, 1, tzinfo=UTC), datetime(2022, 8, 1, tzinfo=UTC), True),
-        (datetime(2021, 1, 1, tzinfo=UTC), datetime(2022, 1, 1, tzinfo=UTC), True),
-        (datetime(2023, 1, 1, tzinfo=UTC), datetime(2025, 1, 1, tzinfo=UTC), True),
-        # outside
-        (datetime(2021, 1, 1, tzinfo=UTC), datetime(2021, 9, 1, tzinfo=UTC), False),
-        (datetime(2023, 1, 2, tzinfo=UTC), datetime(2025, 1, 1, tzinfo=UTC), False),
-    ],
-)
-@pytest.mark.usefixtures("read_only_db_with_users")
-def test_user_query_by_cosupervisor_start_end(sarc_client, start, end, expected):
-    cosupervisor = UUID("1f9b04e5-0ec4-4577-9196-2b03d254e344")
-    data = sarc_client.user_query(
-        co_supervisor=cosupervisor, co_supervisor_start=start, co_supervisor_end=end
-    )
-    assert isinstance(data, list)
-    if expected:
-        assert len(data) == 1
-        assert str(data[0]) == "8b4fef2b-8f47-4eb6-9992-3e7e1133b42a"
-    else:
-        assert not data
-
-
-@pytest.mark.usefixtures("read_only_db_with_users")
-def test_user_query_by_cosupervisor_bad_start_end(sarc_client):
-    # Corresponds to test_user_query_by_cosupervisor_bad_start_end in test_v0
-    start = datetime(2022, 1, 1, tzinfo=UTC)
-    end = start - timedelta(days=1)
-    # Should raise 400 Bad Request
-    with pytest.raises(httpx.HTTPStatusError) as excinfo:
-        sarc_client.user_query(
-            co_supervisor=UUID("1f9b04e5-0ec4-4577-9196-2b03d254e344"),
-            co_supervisor_start=start,
-            co_supervisor_end=end,
-        )
-    assert excinfo.value.response.status_code == 400
-
-
-@pytest.mark.usefixtures("read_only_db_with_users")
-def test_user_query_empty_result(sarc_client):
-    # Corresponds to test_user_query_empty_result in test_v0
-    uuids = sarc_client.user_query(email="nothing@nothing.nothing")
-    assert len(uuids) == 0
-
-
-@pytest.mark.usefixtures("read_only_db_with_users")
-def test_user_query_no_filters(sarc_client):
-    # Corresponds to test_user_query_no_filters in test_v0
-    data = sarc_client.user_query()
-    assert len(data) == 10
-
-
-@pytest.mark.usefixtures("read_only_db_with_users")
-def test_user_query_multiple_filters(sarc_client):
-    # Corresponds to test_user_query_multiple_filters in test_v0
-    data = sarc_client.user_query(
-        supervisor=UUID("1f9b04e5-0ec4-4577-9196-2b03d254e344"),
-        supervisor_start=datetime(2020, 1, 1, tzinfo=UTC),
-        display_name="sMiTh",
-    )
-    assert len(data) == 1
-    assert str(data[0]) == "7ecd3a8a-ab71-499e-b38a-ceacd91a99c4"
-
-    user = sarc_client.user_by_id(data[0])
-    assert user.display_name == "John Smith"
-    assert user.uuid == data[0]
-
-
-@pytest.mark.usefixtures("read_only_db_with_users")
-def test_get_user_by_uuid(sarc_client):
-    user = sarc_client.user_by_id("7ecd3a8a-ab71-499e-b38a-ceacd91a99c4")
-    assert user.email == "jsmith@example.com"
-
-
-@pytest.mark.usefixtures("read_only_db_with_users")
-def test_get_user_by_uuid_invalid(sarc_client):
-    with pytest.raises(httpx.HTTPStatusError) as excinfo:
-        sarc_client.user_by_id("invalid")
-    assert excinfo.value.response.status_code == 422
-
-
-@pytest.mark.usefixtures("read_only_db_with_users")
-def test_get_user_by_uuid_unknown(sarc_client):
-    # Corresponds to test_get_user_by_uuid_unknown in test_v0
-    unknown_uuid = "70000000-a000-4000-b000-c00000000000"
-    with pytest.raises(httpx.HTTPStatusError) as excinfo:
-        sarc_client.user_by_id(unknown_uuid)
-    assert excinfo.value.response.status_code == 404
-
-
-@pytest.mark.usefixtures("read_only_db_with_users")
+@pytest.mark.usefixtures("read_only_db")
 def test_get_user_by_email(sarc_client):
-    email = "jsmith@example.com"
-    user = sarc_client.user_by_email(email)
-    assert user.email == email
+    user = sarc_client.get_user_by_email("jsmith@example.com")
+    assert user.email == "jsmith@example.com"
     assert user.display_name == "John Smith"
-    assert str(user.uuid) == "7ecd3a8a-ab71-499e-b38a-ceacd91a99c4"
-
-
-@pytest.mark.usefixtures("read_only_db_with_users")
-def test_get_user_by_email_unknown(sarc_client):
-    # Corresponds to test_get_user_by_email_unknown in test_v0
-    with pytest.raises(httpx.HTTPStatusError) as excinfo:
-        sarc_client.user_by_email("unknown")
-    assert excinfo.value.response.status_code == 404
-
-
-@pytest.mark.usefixtures("read_only_db_with_users")
-def test_user_list(sarc_client):
-    """Test user list with pagination."""
-    # Default page 1
-    data = sarc_client.user_list()
-    assert data.page == 1
-    assert data.total == 10
-    assert len(data.users) == 10
-    assert data.per_page == config().api.per_page
-
-    # Check sorting: email asc
-    emails = [u.email for u in data.users]
-    assert emails == sorted(emails)
-
-    # Page 2
-    data = sarc_client.user_list(page=2)
-    assert data.page == 2
-    assert data.total == 10
-    assert len(data.users) == 0
-
-    # Test filtering with list endpoint
-    data = sarc_client.user_list(display_name="janE")
-    assert data.total == 1
-    assert len(data.users) == 1
-    assert data.users[0].display_name == "Jane Doe"
-
-
-@pytest.mark.usefixtures("read_only_db_with_users")
-def test_user_list_per_page_3(sarc_client):
-    prev_users = []
-    for page in range(1, 4):
-        users_list = sarc_client.user_list(page=page, per_page=3)
-        assert users_list.total == 10
-        assert users_list.per_page == 3
-        assert len(users_list.users) == 3
-        assert users_list.page == page
-        assert prev_users != users_list.users
-        prev_users = users_list.users
-
-    users_list = sarc_client.user_list(page=4, per_page=3)
-    assert users_list.total == 10
-    assert users_list.per_page == 3
-    assert len(users_list.users) == 1
-    assert users_list.page == 4
-    assert prev_users != users_list.users
-
-    for page in range(5, 10):
-        users_list = sarc_client.user_list(page=page, per_page=3)
-        assert users_list.total == 10
-        assert users_list.per_page == 3
-        assert len(users_list.users) == 0
-        assert users_list.page == page
-
-
-@pytest.mark.usefixtures("read_only_db_with_users")
-def test_job_list_no_filters(sarc_client):
-    jobs_list = sarc_client.job_list()
-    assert jobs_list.page == 1
-    assert jobs_list.total == 24
-    assert len(jobs_list.jobs) == 24
-    assert jobs_list.per_page == config().api.per_page
-
-
-@pytest.mark.usefixtures("read_only_db_with_users")
-def test_job_list(sarc_client):
-    # We expect 20 jobs in raisin cluster
-    prev_jobs = []
-    for page in range(1, 5):
-        jobs_list = sarc_client.job_list(cluster="raisin", page=page, per_page=5)
-        assert jobs_list.total == 20
-        assert jobs_list.per_page == 5
-        assert len(jobs_list.jobs) == 5
-        assert jobs_list.page == page
-        assert prev_jobs != jobs_list.jobs
-        prev_jobs = jobs_list.jobs
-
-    for page in range(6, 10):
-        jobs_list = sarc_client.job_list(cluster="raisin", page=page, per_page=5)
-        assert jobs_list.total == 20
-        assert jobs_list.per_page == 5
-        assert len(jobs_list.jobs) == 0
-        assert jobs_list.page == page
-
-
-# Test High-Level Client Functions
-
-
-@pytest.mark.usefixtures("read_only_db_with_users")
-def test_rest_count_jobs(mock_client_class):
-    """Test the top-level count_jobs function."""
-    from sarc.rest.client import count_jobs
-
-    count = count_jobs(cluster="raisin")
-    assert count == 20
-
-    count = count_jobs(cluster="raisin", job_state="COMPLETED")
-    assert count == 1
-
-    # Invalid cluster should return 0 (not raise exception)
-    count = count_jobs(cluster="nonexistent_cluster")
-    assert count == 0
-
-
-@pytest.mark.usefixtures("read_only_db_with_users")
-def test_rest_get_job(mock_client_class):
-    """Test get_job returns a single job when found."""
-    from sarc.rest.client import get_job
-
-    job = get_job(cluster="raisin", job_id=10)
-    assert job is not None
-    assert isinstance(job, SlurmJob)
-    assert job.job_id == 10
-    assert job.cluster_name == "raisin"
-
-    # Use a non-existent job ID
-    job = get_job(job_id=9999999999)
-    assert job is None
-
-    # Use a non-existent cluster
-    job = get_job(cluster="nonexistent_cluster", job_id=10)
-    assert job is None
-
-
-@pytest.mark.usefixtures("read_only_db_with_users")
-def test_rest_get_jobs(mock_client_class):
-    """
-    Test the top-level get_jobs function which should iterate over pages.
-    """
-    from sarc.rest.client import get_jobs
-
-    # Call the helper function
-    all_jobs = list(get_jobs(cluster="raisin"))
-
-    assert len(all_jobs) == 20
-    assert isinstance(all_jobs[0], SlurmJob)
-    # Verify all jobs are from raisin cluster
-    assert all(job.cluster_name == "raisin" for job in all_jobs)
-
-    # Test with non-existent cluster
-    assert len(list(get_jobs(cluster="nonexistent_cluster"))) == 0
-
-
-@pytest.mark.usefixtures("read_only_db_with_users")
-def test_rest_get_users(mock_client_class):
-    """
-    Test the top-level get_users function which should iterate over pages.
-    """
-    from sarc.core.models.users import UserData
-    from sarc.rest.client import get_users
-
-    # Call the helper function
-    all_users = get_users()
-
-    assert len(all_users) == 10
-    assert isinstance(all_users[0], UserData)
-
-    # Verify sorting by email (default)
-    emails = [u.email for u in all_users]
-    assert emails == sorted(emails)
-
-    # Test with filter
-    doe_users = get_users(display_name="Doe")
-    assert len(doe_users) == 1
-    assert doe_users[0].display_name == "Jane Doe"
-
-
-# Test job_id list via SarcApiClient
 
 
 @pytest.mark.usefixtures("read_only_db")
-def test_get_jobs_by_job_id_list(sarc_client):
-    """Test job_query with a list of job IDs."""
-    data = sarc_client.job_query(job_id=[8, 9])
-    assert len(data) == 2
-    for jid in data:
-        job = sarc_client.job_by_id(jid)
-        assert job.job_id in [8, 9]
+def test_get_user_by_email_not_found(sarc_client):
+    with pytest.raises(httpx.HTTPStatusError) as exc:
+        sarc_client.get_user_by_email("nobody@nowhere.example")
+    assert exc.value.response.status_code == 404
 
 
 @pytest.mark.usefixtures("read_only_db")
-def test_count_jobs_by_job_id_list(sarc_client):
-    """Test job_count with a list of job IDs."""
-    count = sarc_client.job_count(job_id=[8, 9])
-    assert count == 2
+def test_get_clusters(sarc_client):
+    clusters = sarc_client.get_clusters()
+    names = {c.name for c in clusters}
+    assert {"raisin", "fromage", "patate"}.issubset(names)
 
 
 @pytest.mark.usefixtures("read_only_db")
-def test_job_list_by_job_id_list(sarc_client):
-    """Test job_list with a list of job IDs."""
-    result = sarc_client.job_list(job_id=[8, 9])
-    assert result.total == 2
-    assert len(result.jobs) == 2
-    job_ids = [job.job_id for job in result.jobs]
-    assert 8 in job_ids
-    assert 9 in job_ids
-
-
-# Test get_rgus version handling
-
-
-def test_rest_get_rgus_unsupported_version(mock_client_class):
-    """Test get_rgus raises NotImplementedError for unsupported version."""
-    from sarc.rest.client import get_rgus
-
-    with pytest.raises(NotImplementedError, match="rgu_version != 1.0"):
-        get_rgus(rgu_version="2.0")
-
-
-# Test pagination validation errors
-
-
-@pytest.mark.usefixtures("read_only_db")
-def test_job_list_page_less_than_one(sarc_client):
-    """Test job_list with page < 1 raises 400 error."""
-    with pytest.raises(httpx.HTTPStatusError) as excinfo:
-        sarc_client.job_list(page=0)
-    assert excinfo.value.response.status_code == 400
-    assert "Page must be >= 1" in excinfo.value.response.json()["detail"]
-
-
-@pytest.mark.usefixtures("read_only_db")
-def test_job_list_per_page_less_than_one(sarc_client):
-    """Test job_list with per_page < 1 raises 400 error."""
-    with pytest.raises(httpx.HTTPStatusError) as excinfo:
-        sarc_client.job_list(per_page=0)
-    assert excinfo.value.response.status_code == 400
-    assert "Page size must be >= 1" in excinfo.value.response.json()["detail"]
-
-
-@pytest.mark.usefixtures("read_only_db")
-def test_job_list_per_page_exceeds_max(sarc_client):
-    """Test job_list with per_page > MAX_PAGE_SIZE raises 400 error."""
-    with pytest.raises(httpx.HTTPStatusError) as excinfo:
-        sarc_client.job_list(per_page=config().api.max_page_size + 1)
-    assert excinfo.value.response.status_code == 400
-    assert "Page size must be <=" in excinfo.value.response.json()["detail"]
-
-
-@pytest.mark.usefixtures("read_only_db_with_users")
-def test_user_list_page_less_than_one(sarc_client):
-    """Test user_list with page < 1 raises 400 error."""
-    with pytest.raises(httpx.HTTPStatusError) as excinfo:
-        sarc_client.user_list(page=0)
-    assert excinfo.value.response.status_code == 400
-    assert "Page must be >= 1" in excinfo.value.response.json()["detail"]
-
-
-@pytest.mark.usefixtures("read_only_db_with_users")
-def test_user_list_per_page_less_than_one(sarc_client):
-    """Test user_list with per_page < 1 raises 400 error."""
-    with pytest.raises(httpx.HTTPStatusError) as excinfo:
-        sarc_client.user_list(per_page=0)
-    assert excinfo.value.response.status_code == 400
-    assert "Page size must be >= 1" in excinfo.value.response.json()["detail"]
-
-
-@pytest.mark.usefixtures("read_only_db_with_users")
-def test_user_list_per_page_exceeds_max(sarc_client):
-    """Test user_list with per_page > MAX_PAGE_SIZE raises 400 error."""
-    with pytest.raises(httpx.HTTPStatusError) as excinfo:
-        sarc_client.user_list(per_page=config().api.max_page_size + 1)
-    assert excinfo.value.response.status_code == 400
-    assert "Page size must be <=" in excinfo.value.response.json()["detail"]
+def test_get_rgus(sarc_client, monkeypatch):
+    monkeypatch.setattr("sarc.api.v0.get_rgus", lambda: {"A100": 3.21})
+    rgus = sarc_client.get_rgus()
+    assert rgus == {"A100": 3.21}

--- a/tests/functional/api/test_v0.py
+++ b/tests/functional/api/test_v0.py
@@ -243,7 +243,7 @@ def test_get_jobs_invalid_pagination(client):
         client.get("/v0/job/query?limit=0")
     # Limit > MAX
     with pytest.raises(ValidationError):
-        client.get(f"/v0/job/query?limit={config().api.max_page_size + 1}")
+        client.get("/v0/job/query?limit=101")
 
 
 @pytest.mark.usefixtures("read_only_db")
@@ -283,7 +283,9 @@ def test_count_jobs(client, params, expected):
 @pytest.mark.usefixtures("read_only_db")
 def test_count_jobs_invalid_cluster(client):
     """Test jobs count with invalid cluster."""
-    response = client.get("/v0/job/count?cluster_name=invalid_cluster", expect_status=404)
+    response = client.get(
+        "/v0/job/count?cluster_name=invalid_cluster", expect_status=404
+    )
 
     data = response.json()
     assert "No such cluster 'invalid_cluster'" in data["detail"]

--- a/tests/sarc-test.yaml
+++ b/tests/sarc-test.yaml
@@ -130,7 +130,7 @@ sarc:
     uri: "https://localhost/loki"
   tempo:
     uri: "https://localhost/tempo"
-  api:
+  server:
     auth:
       client_id: "mock_client_id"
       client_secret: "dHPf4JQhK9VutnlJlcln"


### PR DESCRIPTION
* Reimplement SarcClient from scratch
* The config was a bit confused, mixing api and server (my fault), so: sarc.api.auth -> sarc.server.auth
* The config for SarcClient is now the object itself, see below

To load a SarcClient, you have the following options:

```python
from sarc.rest import SarcClient

SarcClient(base_url=...)
SarcClient.load()  # Get from the sarc.client section of the configuration
SarcClient.load("file.yaml")  # Read the client from file.yaml
SarcClient.load("pyproject.toml:sarc")  # Read from the [sarc] section of pyproject.toml (the notation also works for yaml or json)
```
