### PR TITLE
[SARC-629] Remove invalid raw prometheus values before computing statistics

### DIFF
--- a/sarc/scraping/dcgm.py
+++ b/sarc/scraping/dcgm.py
@@ -1,0 +1,18 @@
+"""NVIDIA DCGM sentinel values and helpers.
+
+DCGM publishes special "BLANK" values when a metric is unavailable
+(e.g. profiling paused, GPU not accessible, MIG slice not enabled). These
+sentinels reach SARC via Prometheus exporters such as dcgm-exporter and
+pollute statistics if not filtered before aggregation.
+
+Constants and semantics mirror NVIDIA/DCGM ``testing/python3/dcgmvalue.py``:
+https://github.com/NVIDIA/DCGM/blob/master/testing/python3/dcgmvalue.py
+"""
+
+DCGM_INT64_BLANK = 0x7FFF_FFFF_FFFF_FFF0
+DCGM_INT32_BLANK = 0x7FFF_FFF0
+DCGM_FP64_BLANK = 140737488355328.0  # 2**47 == 0x8000_0000_0000
+
+DCGM_FP64_NOT_FOUND = DCGM_FP64_BLANK + 1.0
+DCGM_FP64_NOT_SUPPORTED = DCGM_FP64_BLANK + 2.0
+DCGM_FP64_NOT_PERMISSIONED = DCGM_FP64_BLANK + 3.0

--- a/sarc/scraping/series.py
+++ b/sarc/scraping/series.py
@@ -8,6 +8,7 @@ from prometheus_api_client.metric_range_df import MetricRangeDataFrame
 
 from sarc.config import UTC, config
 from sarc.db.job import JobStatisticDB, SlurmJobDB
+from sarc.scraping.dcgm import DCGM_FP64_BLANK
 from sarc.traces import trace_decorator
 
 logger = logging.getLogger(__name__)
@@ -137,6 +138,13 @@ def compute_job_statistics_from_dataframe(
         return None
 
     df = df.reset_index()
+
+    # Drop DCGM BLANK sentinels (2**47 and the NOT_FOUND/NOT_SUPPORTED/
+    # NOT_PERMISSIONED variants) that the GPU exporter forwards untouched
+    # when a metric is unavailable; otherwise they pollute mean/max/quantiles.
+    df = df[df["value"] < DCGM_FP64_BLANK]
+    if df.empty:
+        return None
 
     groupby = ["instance", "core", "gpu"]
     groupby = [col for col in groupby if col in df]

--- a/tests/unittests/jobs/test_series.py
+++ b/tests/unittests/jobs/test_series.py
@@ -5,6 +5,12 @@ import pandas
 import pytest
 from pandas import DataFrame
 
+from sarc.scraping.dcgm import (
+    DCGM_FP64_BLANK,
+    DCGM_FP64_NOT_FOUND,
+    DCGM_FP64_NOT_PERMISSIONED,
+    DCGM_FP64_NOT_SUPPORTED,
+)
 from sarc.scraping.series import compute_job_statistics_from_dataframe
 
 
@@ -56,6 +62,35 @@ def test_compute_job_statistics_from_dataframe_time_counter(delta):
         df, {"mean": lambda self: self.mean()}, is_time_counter=True
     )
     assert stats == {"mean": (75 / delta + 15 / delta) / 2, "unused": 0}
+
+
+def test_compute_job_statistics_from_dataframe_filters_dcgm_blank():
+    # Mix of valid values and DCGM sentinels (BLANK + the three error
+    # variants). All sentinels must be discarded so that stats reflect only
+    # the valid samples.
+    sentinels = [
+        DCGM_FP64_BLANK,
+        DCGM_FP64_NOT_FOUND,
+        DCGM_FP64_NOT_SUPPORTED,
+        DCGM_FP64_NOT_PERMISSIONED,
+    ]
+    rows = [{"instance": "cn-c002", "value": v} for v in [1.0, 2.0, 3.0, *sentinels]]
+    df = _generate_df(rows)
+    stats = compute_job_statistics_from_dataframe(
+        df,
+        {"mean": lambda self: self.mean(), "max": lambda self: self.max()},
+        unused_threshold=None,
+    )
+    assert stats == {"mean": 2.0, "max": 3.0, "unused": 0}
+
+
+def test_compute_job_statistics_from_dataframe_all_blank_returns_none():
+    rows = [{"instance": "cn-c002", "value": DCGM_FP64_BLANK} for _ in range(5)]
+    df = _generate_df(rows)
+    stats = compute_job_statistics_from_dataframe(
+        df, {"mean": lambda self: self.mean()}
+    )
+    assert stats is None
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
With help from Claude Code.

Remove invalid raw prometheus values before computing statistics.

Invalid data seem to have an explicit value (`DCGM_FP64_BLANK = 140737488355328.0  # 2**47`) defined here: https://github.com/NVIDIA/DCGM/blob/master/testing/python3/dcgmvalue.py