### PR TITLE
sync cluster end times from cache on db init

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,8 @@ sarc-test-cache
 dbconfig.txt
 token.json
 .vscode
+.zed
+.claude
 .mypy_cache
 GEMINI.md
 CLAUDE.md

--- a/sarc/cache.py
+++ b/sarc/cache.py
@@ -34,6 +34,11 @@ class CacheEntry:
         """Add a key-value pair to the cache entry"""
         self._zf.writestr(key, value)
 
+    def keys(self) -> Iterator[str]:
+        """Get all key names without loading the values."""
+        for zi in self._zf.infolist():
+            yield zi.filename
+
     def items(self) -> Iterator[tuple[str, bytes]]:
         """Get all the key, value pairs in the order they were added."""
         for zi in self._zf.infolist():
@@ -271,6 +276,34 @@ class Cache:
                             ZipFile(file, mode="r"), self._datetime_from_path(file)
                         )
         return None
+
+    def read_backward(self) -> Iterator[CacheEntry]:
+        """Yield all cache entries in reverse chronological order."""
+        cdir = self.cache_dir
+        ignore = {".DS_Store"}
+        for year_dir in sorted(
+            filter(lambda p: p.name not in ignore, cdir.iterdir()),
+            key=_basename_to_int,
+            reverse=True,
+        ):
+            for month_dir in sorted(
+                filter(lambda p: p.name not in ignore, year_dir.iterdir()),
+                key=_basename_to_int,
+                reverse=True,
+            ):
+                for day_dir in sorted(
+                    filter(lambda p: p.name not in ignore, month_dir.iterdir()),
+                    key=_basename_to_int,
+                    reverse=True,
+                ):
+                    for file in sorted(
+                        filter(no_current, day_dir.iterdir()),
+                        key=_basename_to_time,
+                        reverse=True,
+                    ):
+                        yield CacheEntry(
+                            ZipFile(file, mode="r"), self._datetime_from_path(file)
+                        )
 
     def oldest_year(self) -> datetime:
         """

--- a/sarc/cache.py
+++ b/sarc/cache.py
@@ -279,7 +279,11 @@ class Cache:
 
     def read_backward(self) -> Iterator[CacheEntry]:
         """Yield all cache entries in reverse chronological order."""
-        cdir = self.cache_dir
+        root = config.cache
+        assert root is not None
+        cdir = root / self.subdirectory
+        if not cdir.exists():
+            return
         ignore = {".DS_Store"}
         for year_dir in sorted(
             filter(lambda p: p.name not in ignore, cdir.iterdir()),

--- a/sarc/db/__init__.py
+++ b/sarc/db/__init__.py
@@ -90,14 +90,19 @@ def sync_cluster_end_times(sess: Session) -> None:
 
     # -- apply to DB --
     for cluster_name, db_cluster in db_clusters.items():
-        start_dt = datetime.combine(db_cluster.start_date, datetime.min.time(), tzinfo=UTC)
+        start_dt = datetime.combine(
+            db_cluster.start_date, datetime.min.time(), tzinfo=UTC
+        )
 
         new_sacct = sacct_times.get(cluster_name, start_dt)
         if db_cluster.end_time_sacct is None or new_sacct > db_cluster.end_time_sacct:
             db_cluster.end_time_sacct = new_sacct
 
         new_prom = prom_times.get(cluster_name, start_dt)
-        if db_cluster.end_time_prometheus is None or new_prom > db_cluster.end_time_prometheus:
+        if (
+            db_cluster.end_time_prometheus is None
+            or new_prom > db_cluster.end_time_prometheus
+        ):
             db_cluster.end_time_prometheus = new_prom
 
 

--- a/sarc/db/__init__.py
+++ b/sarc/db/__init__.py
@@ -30,7 +30,75 @@ def init_insert() -> None:
     with config.db.session() as sess:
         insert_clusters(sess)
         insert_rgu(sess)
+        sync_cluster_end_times(sess)
         sess.commit()
+
+
+def sync_cluster_end_times(sess: Session) -> None:
+    """Update end_time_sacct and end_time_prometheus based on latest cache entries.
+
+    Scans the cache backward (most recent first) to find the latest entry per
+    cluster and updates the DB fields only when the found time is more recent
+    than the current value. Falls back to cluster start_date when no cache
+    entry exists for a given cluster. Prometheus search is skipped for clusters
+    without a prometheus_url to avoid scanning a potentially large cache for
+    nothing.
+    """
+    from datetime import UTC, datetime
+
+    from sarc.cache import Cache
+    from sarc.config import config
+
+    from .cluster import SlurmClusterDB
+
+    if config.cache is None:
+        return
+
+    clusters_cfg = config.clusters
+    db_clusters = {c.name: c for c in sess.exec(select(SlurmClusterDB)).all()}
+
+    # -- jobs cache → end_time_sacct --
+    pending = set(db_clusters.keys())
+    sacct_times: dict[str, datetime] = {}
+    for ce in Cache("jobs").read_backward():
+        if not pending:
+            break
+        entry_time = ce.get_entry_datetime()
+        for key in ce.keys():
+            cluster_name = key.split("_")[0]
+            if cluster_name in pending:
+                sacct_times[cluster_name] = entry_time
+                pending.discard(cluster_name)
+
+    # -- prometheus cache → end_time_prometheus (skip clusters without URL) --
+    prom_enabled = {
+        name
+        for name, cfg in clusters_cfg.items()
+        if cfg.prometheus_url is not None and name in db_clusters
+    }
+    pending = set(prom_enabled)
+    prom_times: dict[str, datetime] = {}
+    for ce in Cache("prometheus").read_backward():
+        if not pending:
+            break
+        entry_time = ce.get_entry_datetime()
+        for key in ce.keys():
+            cluster_name = key.split("$")[0]
+            if cluster_name in pending:
+                prom_times[cluster_name] = entry_time
+                pending.discard(cluster_name)
+
+    # -- apply to DB --
+    for cluster_name, db_cluster in db_clusters.items():
+        start_dt = datetime.combine(db_cluster.start_date, datetime.min.time(), tzinfo=UTC)
+
+        new_sacct = sacct_times.get(cluster_name, start_dt)
+        if db_cluster.end_time_sacct is None or new_sacct > db_cluster.end_time_sacct:
+            db_cluster.end_time_sacct = new_sacct
+
+        new_prom = prom_times.get(cluster_name, start_dt)
+        if db_cluster.end_time_prometheus is None or new_prom > db_cluster.end_time_prometheus:
+            db_cluster.end_time_prometheus = new_prom
 
 
 def insert_clusters(sess: Session) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -214,6 +214,10 @@ class DbConfiguration:
         with custom_db_config(db_name):
             self.executive(f'CREATE DATABASE "{db_name}"')
             command.upgrade(Config(toml_file="pyproject.toml"), "head")
+            # Alembic reuses config.db.engine, leaving a pooled connection that
+            # predates the ALTER DATABASE SET timezone=UTC migration. Dispose so
+            # init_insert() gets a fresh connection that inherits UTC.
+            config.db.engine.dispose()
             init_insert()
             try:
                 if not self.empty:


### PR DESCRIPTION
During `init_insert`, scan the jobs and prometheus caches backward to find the most recent entry per cluster and set `end_time_sacct` / `end_time_prometheus` in the clusters table accordingly. Fields are only advanced (never regressed), and fall back to the cluster's `start_date` when no cache entry is found. Prometheus scanning is skipped entirely for clusters without a `prometheus_url`. Adds `Cache.read_backward()` and `CacheEntry.keys()` to support efficient reverse iteration without loading entry data.