### PR TITLE
fix SlurmJobDB to handle gracefully `SlurmJobDB.statistics` replacement

### DIFF
--- a/sarc/db/job.py
+++ b/sarc/db/job.py
@@ -105,7 +105,7 @@ class SlurmJobDB(SQLModel, table=True):
         sa_relationship=relationship(
             JobStatisticDB,
             collection_class=attribute_keyed_dict("name"),
-            cascade="all, delete-orphan",
+            passive_deletes="all",
         )
     )
 

--- a/sarc/db/job.py
+++ b/sarc/db/job.py
@@ -103,7 +103,9 @@ class SlurmJobDB(SQLModel, table=True):
 
     statistics: dict[str, JobStatisticDB] = Relationship(
         sa_relationship=relationship(
-            JobStatisticDB, collection_class=attribute_keyed_dict("name")
+            JobStatisticDB,
+            collection_class=attribute_keyed_dict("name"),
+            cascade="all, delete-orphan",
         )
     )
 


### PR DESCRIPTION
fix SlurmJobDB to handle gracefully statistics replacement (during parse prometheus), avoiding the error 'null value in column "job_id" of relation "jobstatisticdb" violates not-null constraint'

The error was:
```
sqlalchemy.exc.ProgrammingError: (raised as a result of Query-invoked autoflush; consider using a session.no_autoflush block if this flush is occurring prematurely)
(pg8000.dbapi.ProgrammingError) {'S': 'ERROR', 'V': 'ERROR', 'C': '23502', 'M': 'null value in column "job_id" of relation "jobstatisticdb" violates not-null constraint', 'D': 'Failing row contains (7619136, null, gpu_utilization, 0.9187540983606557, 0.07421237348924077, 0.89, 0.89, 0.89, 0.97, 1, 0).', 's': 'public', 't': 'jobstatisticdb', 'c': 'job_id', 'F': 'execMain.c', 'L': '2219', 'R': 'ReportNotNullViolationError'}
[SQL: UPDATE jobstatisticdb SET job_id=%s::INTEGER WHERE jobstatisticdb.id = %s::INTEGER]
[parameters: [(None, 7619136), (None, 7619137), (None, 7619138), (None, 7619139)]]
(Background on this error at: https://sqlalche.me/e/20/f405)
```

It was due to parsing a prometheus refetch, causing SQLalchemy to replace a `jobstatisticdb` in 3 steps:
- detach old stat by setting `job_id = None` to old jobstatisticdb entry
- add new jobstatisticdb, with the correct job_id
- delete old jobstatisticdb entry

But the first step was forbidden by design. 

Now, the entry is automatically deleted when `SlurmJobDB.statistics` is set to a new dict of `JobStatisticDB` 