### PR TITLE
Allow disabling the ssl cert check for prometheus connections

### DIFF
--- a/sarc/config.py
+++ b/sarc/config.py
@@ -70,6 +70,7 @@ class ClusterConfig:
     timezone: zoneinfo.ZoneInfo | None = None
     prometheus_url: str | None = None
     prometheus_headers: dict[str, Secret[str]] | str = field(default_factory=dict)
+    prometheus_check_ssl: bool = True
     name: str | None = None
     sacct_bin: str = "sacct"
     ignore_tz_utc: bool = False
@@ -198,7 +199,11 @@ class ClusterConfig:
             headers["Authorization"] = f"Bearer {credentials.token}"
         elif isinstance(self.prometheus_headers, dict):
             headers = self.prometheus_headers
-        return PrometheusConnect(url=self.prometheus_url, headers=headers)
+        return PrometheusConnect(
+            url=self.prometheus_url,
+            headers=headers,
+            disable_ssl=not self.prometheus_check_ssl,
+        )
 
 
 def get_db_user() -> str:


### PR DESCRIPTION
This seems to be the simplest solution to be able to query prometheus metrics from our GCP deployment over the private IP (and thus avoid double-billed network charges).