### PR TITLE
Add hatch envs for dev setup, secrets, and local postgres

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,3 +149,132 @@ name = "ruff_format"
 type = "exec"
 executable = "ruff"
 options = "format REVISION_SCRIPT_FILENAME"
+
+[tool.hatch.envs.default]
+installer = "uv"
+dependency-groups = ["dev"]
+
+[tool.hatch.envs.default.env-vars]
+SARC_CONFIG = "{env:SARC_CONFIG:{root:real}/config/sarc-dev.secrets.yaml}"
+SERIEUX_PASSWORD = "{env:SERIEUX_PASSWORD:_}"
+SARC_SECRETS = "{env:SARC_SECRETS:{home:real}/secrets/sarc/config.yaml}"
+
+[tool.hatch.envs.default.scripts]
+uv = 'UV_PROJECT_ENVIRONMENT="{env:VIRTUAL_ENV}" "$(which uv)" {args}'
+make-secrets = [
+    "uv sync",
+    'serieux patch -m "sarc.config:Config" -o "$(echo "{env:SARC_CONFIG}" | cut -d"," -f1)" "{env:SARC_SECRETS}:sarc" {args}',
+]
+
+[tool.hatch.envs.pixi]
+detached = true
+installer = "uv"
+
+[tool.hatch.envs.pixi.scripts]
+install-linux = [
+    """which pixi && exit 0 \
+        || curl -fsSL https://pixi.sh/install.sh | sh"""
+]
+install-macos = [
+   "install-linux"
+]
+
+[tool.hatch.envs.pixi.overrides]
+platform.linux.scripts = [
+  "install=install-linux",
+]
+platform.macos.scripts = [
+  "install=install-macos",
+]
+
+[tool.hatch.envs.podman]
+detached = true
+
+[tool.hatch.envs.podman.env-vars]
+PODMAN_VERSION = "{env:PODMAN_VERSION:5.6.1}"
+
+[tool.hatch.envs.podman.scripts]
+install-linux = [
+    """which podman >/dev/null && exit 0 \
+        || hatch run pixi:install-linux""",
+    """which podman >/dev/null && exit 0 \
+        || which pixi >/dev/null 2>&1 || echo 'Please restart or source your shell.' && which pixi >/dev/null 2>&1""",
+    """which podman >/dev/null && exit 0 \
+        || pixi global install -c conda-forge 'podman=={env:PODMAN_VERSION}'"""
+]
+install-macos = [
+    """which podman >/dev/null && exit 0 \
+        || curl -sL https://github.com/containers/podman/releases/download/v{env:PODMAN_VERSION}/podman-installer-macos-universal.pkg \
+        -o /tmp/podman-installer-macos-universal.pkg""",
+    """which podman >/dev/null && exit 0 \
+        || sudo installer -pkg /tmp/podman-installer-macos-universal.pkg -target /""",
+    "podman machine inspect >/dev/null 2>&1 || podman machine init",
+]
+
+[tool.hatch.envs.podman.overrides]
+platform.linux.scripts = [
+  "install=install-linux",
+]
+platform.macos.scripts = [
+  "install=install-macos",
+]
+
+[tool.hatch.envs.postgres]
+template = "podman"
+
+[tool.hatch.envs.postgres.env-vars]
+POSTGRES_USER = "{env:POSTGRES_USER:{env:USER}}"
+POSTGRES_INITDB_ROOT_USERNAME = "{env:POSTGRES_INITDB_ROOT_USERNAME:root}"
+POSTGRES_INITDB_ROOT_PASSWORD = "{env:POSTGRES_INITDB_ROOT_PASSWORD:pass}"
+POSTGRES_INITDB_PORT = "{env:POSTGRES_INITDB_PORT:5432}"
+POSTGRESPOD_NAME = "{env:POSTGRESPOD_NAME:sarc_postgrespod_test}"
+
+[tool.hatch.envs.postgres.scripts]
+start = [
+    "hatch run podman:install",
+    "- podman machine inspect >/dev/null 2>&1 && podman machine start",
+    # Run PostgreSQL 17 in the background:
+    # -dt                                       : detached + allocated TTY.
+    # --name {env:POSTGRESPOD_NAME}             : fixed name so we can stop/remove it later.
+    # -p {env:POSTGRES_INITDB_PORT}:5432/tcp    : expose the standard PostgreSQL port on localhost.
+    # -e POSTGRES_HOST_AUTH_METHOD=trust        : allow connections without a password,
+    #                                             which matches the credential-less URL used by
+    #                                             tests/conftest.py.
+    # -e POSTGRES_USER="{env:POSTGRES_USER}"    : create the superuser role named after the host OS
+    #                                             user, so libpq's default user (the OS user) just works
+    #                                             without having to put a username in the connection URL.
+    # -e POSTGRES_DB=postgres                   : keep the default admin database named "postgres"
+    #                                             (otherwise the image would name it after POSTGRES_USER),
+    #                                             which is what tests/conftest.py connects to.
+    # -c max_connections=300                    : raise the connection cap above the default 100.
+    #                                             Each test creates a fresh DbConfig with its own
+    #                                             SQLAlchemy engine (pool of up to 15 conn) and engines
+    #                                             are not explicitly disposed, so multi-fixture tests
+    #                                             can exceed 100 and trigger "too many clients already".
+    """podman start {env:POSTGRESPOD_NAME} \
+        || podman run -dt \
+        --name {env:POSTGRESPOD_NAME} \
+        -p {env:POSTGRES_INITDB_PORT}:5432/tcp \
+        -e POSTGRES_HOST_AUTH_METHOD=trust \
+        -e POSTGRES_USER="{env:POSTGRES_USER}" \
+        -e POSTGRES_DB=postgres \
+        docker.io/library/postgres:17 \
+        -c max_connections=300""",
+    """until podman exec {env:POSTGRESPOD_NAME} pg_isready -h localhost -U "{env:POSTGRES_USER}" >/dev/null 2>&1; do
+        sleep 0.2
+    done""",
+    """podman exec {env:POSTGRESPOD_NAME} bash -c ' \
+        psql -U "{env:POSTGRES_USER}" -lqt | grep -qF sarc-dev \
+        || createdb -U "{env:POSTGRES_USER}" sarc-dev \
+    '""",
+    "echo 'PostgreSQL should now be available at localhost:{env:POSTGRES_INITDB_PORT}'"
+]
+stop = [
+    "podman stop {env:POSTGRESPOD_NAME}",
+    # We do not need to keep test postgres container
+    "- podman rm sarc_postgrespod_test",
+]
+restart = [
+    "- stop",
+    "start",
+]


### PR DESCRIPTION
## Summary
Adds `hatch run` scripts that bootstrap a local dev environment end to end — dependency install, dev secrets, and a disposable PostgreSQL 17 container for tests. Opening this as a discussion PR: is unifying devs onto this hatch-env setup worth doing, and could it also replace `tox`?

## Changes
- `default` env: installs deps via `uv sync` and adds `make-secrets` to patch dev secrets with `serieux`, using `SARC_CONFIG`/`SARC_SECRETS`/`SERIEUX_PASSWORD` env vars.
- `pixi` env: installs `pixi` on Linux/macOS as a prerequisite for `podman`.
- `podman` env: installs and initializes `podman` (via `pixi` on Linux, native installer on macOS).
- `postgres` env (templated on `podman`): `start`/`stop`/`restart` scripts spin up a PostgreSQL 17 container matching the credential-less, trust-auth setup `tests/conftest.py` expects, with `max_connections=300` raised for concurrent test fixtures, and creates the `sarc-dev` database.

## Notes
- Open question for reviewers: should this become the standard dev setup for the team, and does it make sense to fold `tox` usage into these hatch envs instead of maintaining both?
- No existing tooling is removed in this PR — it's additive, meant to seed the discussion.
