### PR TITLE
Exclude jobs with no gpu_sm_occupancy stat from underusage calculations

### DIFF
--- a/docs/dev_overview/underusage_notifications.md
+++ b/docs/dev_overview/underusage_notifications.md
@@ -67,7 +67,7 @@ identity/display fields:
 | Column | What it is |
 |---|---|
 | `allocated_gpu_cost` | Allocated GPU cost in RGU-seconds (`elapsed × gpus × drac_rgu`); `/3600` gives allocated RGU-hours. |
-| `allocated_gpu_waste` | Unused portion of that cost in RGU-seconds (`(1 − gpu_sm_occupancy) × allocated_gpu_cost`); the basis for "wasted". |
+| `allocated_gpu_waste` | Unused portion of that cost in RGU-seconds (`(1 − gpu_sm_occupancy) × allocated_gpu_cost`); the basis for "wasted". NULL/NaN when no `gpu_sm_occupancy` stat was recorded for the job — such jobs are excluded entirely (not counted as fully utilized). |
 | `end_time` | Job end time; the analysis window filters on `start ≤ end_time < end`. |
 | `allocated_gpu_type` | Allocated GPU type; rows with no GPU type are excluded (non-GPU jobs). |
 | `allocated_rgu_drac` | Per-job allocated RGU count; must be non-null for a job to count (guards missing RGU weights). |

--- a/sarc/notifications/underusage.py
+++ b/sarc/notifications/underusage.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass, field
 from datetime import date, datetime, timedelta
 from functools import cached_property
 
-from sqlmodel import Session, case, col, func, select
+from sqlmodel import Session, col, func, select
 
 from sarc.api.metrics import _is_real
 from sarc.config import UTC, config
@@ -31,12 +31,10 @@ class UsageJob:
     job_id: int
     cluster: str
     submit_time: datetime
-    # RGU-hours unused for this job. Equals 0 RGU-hours when utilization is
-    # missing (utilization assumed 100%).
+    # RGU-hours unused for this job.
     wasted: float | None
     rgu_hours_used: float | None
-    # 100% when no gpu_sm_occupancy stat was recorded for this job.
-    gpu_sm_occupancy: float | None
+    gpu_sm_occupancy: float
 
 
 @dataclass
@@ -110,33 +108,23 @@ def _rgu_exprs(utilization_ceiling: float = 1.0):
 
     rgu_h_expr = allocated_gpu_cost / 3600 — allocated RGU-hours (== rgu *
                  elapsed / 3600).
-    true_wasted = allocated_gpu_waste / 3600 = rgu_h * (1 - m), or 0 (fully used,
-                  zero waste) when m is NaN/NULL — no gpu_sm_occupancy stat
-                  recorded.
+    true_wasted = allocated_gpu_waste / 3600 = rgu_h * (1 - m). Jobs with no
+                  gpu_sm_occupancy stat recorded (NaN/NULL allocated_gpu_waste)
+                  are excluded upstream by `_with_rgu_window`, so wasted_raw is
+                  always real here.
     true_used_expr = rgu_h - true_wasted.
     credited_used_expr = rgu_h - GREATEST(0, true_wasted - rgu_h * (1 - T)),
                          with T = utilization_ceiling — algebraically identical
                          to LEAST(rgu_h, rgu_h * (1 - T + m)) since rgu_h >= 0.
                          Waste = rgu_h - credited_used = max(0, rgu_h * (T -
                          m)). At T=1.0, credited == true.
-
-    The `w == w` idiom (NaN != NaN in SQL, and NULL == NULL is NULL) routes
-    both SQL NULL and NaN allocated_gpu_waste to the else branch (zero waste,
-    user not flagged).
     """
     rgu_h_expr = col(JobSeriesDB.allocated_gpu_cost) / 3600.0
+    # Subtract the ceiling on the raw RGU-second columns, before the /3600, so
+    # that allocated_gpu_waste - allocated_gpu_cost * (1 - T) cancels exactly
+    # when the job's occupancy equals T (both sides compute the identical
+    # product).
     wasted_raw = col(JobSeriesDB.allocated_gpu_waste)
-    # Guard and subtract the ceiling on the raw RGU-second columns, before the
-    # /3600, so that allocated_gpu_waste - allocated_gpu_cost * (1 - T) cancels
-    # exactly when the job's occupancy equals T (both sides compute the
-    # identical product).
-    wasted_raw = case(
-        (
-            _is_real(wasted_raw),  # excludes NaN/NULL
-            wasted_raw,
-        ),
-        else_=0.0,
-    )
     true_used_expr = rgu_h_expr - wasted_raw / 3600.0
     credited_used_expr = (
         rgu_h_expr
@@ -151,12 +139,18 @@ def _rgu_exprs(utilization_ceiling: float = 1.0):
 
 
 def _with_rgu_window(stmt, start, end, *, clusters=None):
-    """Apply the end-time / GPU-type / RGU window filters."""
+    """Apply the end-time / GPU-type / RGU window filters.
+
+    Also excludes jobs with no recorded gpu_sm_occupancy stat (NULL/NaN
+    allocated_gpu_waste) — such jobs carry no usage signal and are dropped
+    entirely rather than counted as fully utilized.
+    """
     stmt = stmt.where(
         col(JobSeriesDB.end_time) >= start,
         col(JobSeriesDB.end_time) < end,
         col(JobSeriesDB.allocated_gpu_type).is_not(None),
         col(JobSeriesDB.allocated_rgu_drac).is_not(None),
+        _is_real(col(JobSeriesDB.allocated_gpu_waste)),
     )
     if clusters:
         stmt = stmt.where(col(JobSeriesDB.cluster_name).in_(clusters))
@@ -235,13 +229,11 @@ def _select_jobs_usage(
     )
 
 
-def _job_occupancy(cost: float | None, waste: float | None) -> float:
+def _job_occupancy(cost: float, waste: float) -> float:
     """Recover a job's gpu_sm_occupancy mean from the view's cost/waste columns
-    (waste = (1 - m) * cost), clamped to <= 1.0. Missing stat (waste NULL/NaN)
-    or zero cost -> 1.0 (fully used)."""
-    if cost and waste is not None:
-        return min(1.0, 1.0 - waste / cost)
-    return 1.0
+    (waste = (1 - m) * cost), clamped to <= 1.0. Zero cost -> 1.0 (fully
+    used)."""
+    return min(1.0, 1.0 - waste / cost)
 
 
 def _split_waste(row) -> tuple[float, float, float]:

--- a/tests/unittests/notifications/test_underusage.py
+++ b/tests/unittests/notifications/test_underusage.py
@@ -497,6 +497,9 @@ def test_missing_util_not_flagged(missing_util_db):
 
 
 def test_missing_util_zero_waste(missing_util_db):
+    # bramin's only job has no gpu_sm_occupancy stat, so it's excluded
+    # entirely upstream — he produces no aggregate row at all, even at
+    # zero-value thresholds.
     results = get_underusers(
         _WINDOW_START,
         _WINDOW_END,
@@ -504,16 +507,13 @@ def test_missing_util_zero_waste(missing_util_db):
         min_waste_rgu_hours=0.0,
         top_jobs_per_user=_TOP_JOBS_PER_USER,
     )
-    row = next(r for r in results if r.email == "bramin@mila.quebec")
-    assert row.wasted == pytest.approx(0.0)
-    assert row.true_wasted == pytest.approx(0.0)
+    assert "bramin@mila.quebec" not in {r.email for r in results}
 
 
 def test_missing_util_non_negative_waste_at_sub_threshold(missing_util_db):
-    # Regression guard: at threshold < 1, the NaN/NULL else-branch must keep
-    # credited_used == rgu_h (zero waste) and not apply the subtractive
-    # adjustment, which would yield rgu_h * (1 - T + NaN) = NaN → undefined
-    # waste.
+    # Regression guard: at a sub-1.0 ceiling, bramin's no-stat job must still
+    # be excluded upstream rather than entering the subtractive ceiling
+    # formula (which would otherwise propagate NaN into an undefined waste).
     results = get_underusers(
         _WINDOW_START,
         _WINDOW_END,
@@ -522,17 +522,17 @@ def test_missing_util_non_negative_waste_at_sub_threshold(missing_util_db):
         top_jobs_per_user=_TOP_JOBS_PER_USER,
         utilization_ceiling=0.8,
     )
-    row = next(r for r in results if r.email == "bramin@mila.quebec")
-    assert row.wasted >= 0.0
-    assert row.wasted == pytest.approx(0.0)
+    assert "bramin@mila.quebec" not in {r.email for r in results}
 
 
 def test_missing_util_usage_rgu_hours_used_equals_requested(missing_util_db):
+    # bramin's only job is excluded from the SQL aggregate entirely (no
+    # gpu_sm_occupancy stat), so he never produces a user_data entry and
+    # never reaches get_all_users_usage's usage-floor check at all.
     results = get_all_users_usage(
         _WINDOW_START, _WINDOW_END, top_jobs_per_user=_TOP_JOBS_PER_USER
     )
-    row = next(r for r in results if r.email == "bramin@mila.quebec")
-    assert row.rgu_hours_used == pytest.approx(row.rgu_hours)
+    assert "bramin@mila.quebec" not in {r.email for r in results}
 
 
 # ── Zero-cost jobs (gpu_cost == 0) ────────────────────────────────────────────
@@ -544,15 +544,17 @@ def zero_cost_db(read_write_db):
     users = {u.email.split("@")[0]: u for u in session.exec(select(UserDB)).all()}
     clusters = {c.name: c for c in session.exec(select(SlurmClusterDB)).all()}
     # Zero-elapsed job: gpu_cost = elapsed_time * gpu_count * rgu = 0, but the row
-    # still passes the window filter (allocated_gpu_type and rgu are set). This is
-    # the case the dropped exclude_zero_usage HAVING clause used to filter out.
+    # still passes the window filter (allocated_gpu_type and rgu are set, and a
+    # real gpu_sm_occupancy stat of 0% is recorded so it isn't excluded as a
+    # missing-stat job). This is the case the dropped exclude_zero_usage HAVING
+    # clause used to filter out.
     _add_gpu_job(
         session,
         user_id=users["bramin"].id,
         cluster_id=clusters["mila"].id,
         elapsed_h=0,
         gpu_type=_MILA_GPU_TYPE,
-        utilization=None,
+        utilization=0.0,
         job_id=95001,
     )
     session.commit()


### PR DESCRIPTION
## Summary
Jobs with no recorded `gpu_sm_occupancy` stat were previously treated as fully utilized (zero waste) while still counting their full allocated RGU-hours, which under-reports waste and can mask real underusage. Such jobs are now excluded entirely from every RGU/usage computation in `underusage.py`.

## Changes
- `_with_rgu_window`: added a filter (`_is_real(allocated_gpu_waste)`) so jobs with no occupancy stat produce no rows at all — applies globally to `get_underusers`, `get_all_users_usage`, `get_historical_stats`, and `get_recurring_underusers`.
- `_rgu_exprs`: removed the now-unreachable NaN/NULL `case` guard that previously substituted zero waste; docstrings updated to reflect the new upstream exclusion.
- `_job_occupancy` / `UsageJob.gpu_sm_occupancy`: simplified now that missing-stat jobs never reach this code (tightened to non-optional `float`, dropped the dead "missing → 100%" branch).
- Updated `docs/dev_overview/underusage_notifications.md` to document the new row-inclusion criterion on `allocated_gpu_waste`.
- Rewrote the 3 affected tests in `test_underusage.py` to assert the no-stat user is now absent from results, and adjusted the `zero_cost_db` fixture to use a real `0.0` occupancy stat so it still exercises the zero-division regression guard instead of being swallowed by the new exclusion filter.

## Notes (optional)
Behavior change: reports (Slack digests/DMs, usage reports, historical trends) will now show lower totals for users/clusters with unmonitored jobs, since those jobs no longer count toward allocated RGU-hours at all.
