### PR TITLE
Parallelize recurring-underuser queries; merge usage row types

### DIFF
--- a/sarc/cli/notify/underusage.py
+++ b/sarc/cli/notify/underusage.py
@@ -15,10 +15,10 @@ from sarc.notifications.messages import (
 )
 from sarc.notifications.slack import SendStatus, SlackClient
 from sarc.notifications.underusage import (
-    get_all_users_usage,
     get_cycle_dates,
     get_recurring_underusers,
-    get_underusers,
+    get_underusers_usage,
+    get_users_usage,
 )
 
 logger = logging.getLogger(__name__)
@@ -279,7 +279,7 @@ class UnderusageNotifyCommand:
             )
         _userfacing_print(file=sys.stderr)
 
-        underusage_rows = get_underusers(
+        underusage_rows = get_underusers_usage(
             start,
             end,
             min_waste_ratio=ncfg.min_waste_ratio,
@@ -339,7 +339,7 @@ class UnderusageNotifyCommand:
                 _user_emails = (_user_emails or []) + [
                     f"~{r.email}" for r in underusage_rows
                 ]
-            usage_rows = get_all_users_usage(
+            usage_rows = get_users_usage(
                 usage_start,
                 end,
                 min_usage_rgu_hours=ncfg.usage_report_min_usage_rgu_hours,

--- a/sarc/notifications/messages.py
+++ b/sarc/notifications/messages.py
@@ -7,7 +7,6 @@ from sarc.notifications.mrkdwn import to_slack_mrkdwn
 from sarc.notifications.slack import MENTION_TOKEN
 from sarc.notifications.underusage import (
     RecurringUserRow,
-    UnderuserRow,
     UsageRow,
     usage_cycle_length_weeks,
 )
@@ -72,7 +71,7 @@ def _jobs_section(top_jobs: list, *, rgu_value: Callable, suffix: str) -> str:
 
 
 def build_user_dm(
-    row: UnderuserRow, *, window_weeks: int, window_start: date, window_end: date
+    row: UsageRow, *, window_weeks: int, window_start: date, window_end: date
 ) -> str:
     """Build a plain-text DM for a single underusing researcher."""
     if not config.notifications:
@@ -233,7 +232,7 @@ def build_recurring_table(
 
 
 def build_admin_digest(
-    rows: list[UnderuserRow],
+    rows: list[UsageRow],
     *,
     period: str,
     cluster_share_threshold: float,

--- a/sarc/notifications/underusage.py
+++ b/sarc/notifications/underusage.py
@@ -450,7 +450,7 @@ def get_underusers_usage(
     )
 
     for row in result:
-        row.top_jobs.sort(key=lambda j: j.wasted, reverse=True)
+        row.top_jobs.sort(key=lambda j: j.wasted, reverse=True)  # ty:ignore[no-matching-overload]
         row.top_jobs = row.top_jobs[:top_jobs_per_user]
 
     return result

--- a/sarc/notifications/underusage.py
+++ b/sarc/notifications/underusage.py
@@ -87,45 +87,40 @@ class UsageJob:
 
 
 @dataclass
-class UnderuserRow:
+class UsageRow:
     email: str
     display_name: str
     user_id: int
     # Total RGU-hours allocated over the window.
-    rgu_hours: float
+    rgu_hours: float = 0.0
+    rgu_hours_used: float = 0.0
     # RGU-hours wasted over the window (= rgu_hours - rgu_used). Used for the
     # activity floor: the floor is compared against *wasted* RGU-hours, so that
     # users who waste a significant absolute amount are flagged regardless of
     # their total allocation size.
-    wasted: float
-    # waste_ratio = wasted / rgu_hours  (= 1 - rgu_used / rgu_hours)
-    waste_ratio: float
-    # Unadjusted reference values (utilization_ceiling=1.0 → equal to wasted/waste_ratio).
-    true_wasted: float = 0.0
-    true_waste_ratio: float = 0.0
+    wasted: float = 0.0
     by_cluster: list[UsageClusterBreakdown] = field(default_factory=list)
     # Top-N GPU jobs by RGU-hours unused, descending.
     top_jobs: list[UsageJob] = field(default_factory=list)
+
+    # waste_ratio = wasted / rgu_hours  (= 1 - rgu_used / rgu_hours)
+    @cached_property
+    def waste_ratio(self) -> float:
+        return self.wasted / self.rgu_hours if self.rgu_hours > 0 else 0.0
+
+    # Unadjusted reference values (utilization_ceiling=1.0 → equal to wasted/waste_ratio).
+    @cached_property
+    def true_wasted(self) -> float:
+        return max(0.0, self.rgu_hours - self.rgu_hours_used)
+
+    @cached_property
+    def true_waste_ratio(self) -> float:
+        return self.true_wasted / self.rgu_hours if self.rgu_hours > 0 else 0.0
 
     # avg_utilization = 1 - waste_ratio  (= rgu_used / rgu_hours)
     @cached_property
     def avg_utilization(self) -> float:
         return 1.0 - self.waste_ratio
-
-
-@dataclass
-class UsageRow:
-    email: str
-    display_name: str
-    user_id: int
-    rgu_hours: float
-    rgu_hours_used: float
-    by_cluster: list[UsageClusterBreakdown] = field(default_factory=list)
-    top_jobs: list[UsageJob] = field(default_factory=list)
-
-    @cached_property
-    def avg_utilization(self) -> float:
-        return self.rgu_hours_used / self.rgu_hours
 
 
 @dataclass
@@ -329,17 +324,16 @@ def _split_waste(row) -> tuple[float, float, float]:
     return rgu_h, rgu_h_true_used, rgu_h - rgu_h_used
 
 
-def get_underusers(
+def _get_users_usage(
     start: datetime,
     end: datetime,
     *,
-    min_waste_ratio: float,
-    min_waste_rgu_hours: float,
-    top_jobs_per_user: int,
+    usage_filter: Callable,
+    fetch_jobs_per_user: bool = True,
     clusters: list[str] | None = None,
     utilization_ceiling: float = 1.0,
     user_emails: list[str] | None = None,
-) -> list[UnderuserRow]:
+) -> list[UsageRow]:
     with config.db.session() as session:
         stmt = _select_jobs_usage(
             None,
@@ -357,8 +351,9 @@ def get_underusers(
             uid = row.sarc_user_id
             if uid not in user_data:
                 user_data[uid] = {
-                    "email": row.email,
-                    "display_name": row.display_name,
+                    "usage_data": UsageRow(
+                        email=row.email, display_name=row.display_name, user_id=uid
+                    ),
                     "clusters": [],
                 }
             rgu_h, rgu_h_true_used, rgu_h_wasted = _split_waste(row)
@@ -371,31 +366,28 @@ def get_underusers(
                 )
             )
 
-        # Identify users who meet both threshold conditions: their cross-cluster
-        # aggregated waste ratio and total wasted RGU-hours exceed
-        # `min_waste_ratio` and `min_waste_rgu_hours` respectively.
-        underuser_ids: list[int] = []
-        for uid, u in user_data.items():
+        for uid, u in list(user_data.items()):
+            usage_data: UsageRow = u["usage_data"]
             breakdowns: list[UsageClusterBreakdown] = u["clusters"]
-            total_rgu_h = sum(c.rgu_hours for c in breakdowns)
-            total_wasted = sum(c.wasted for c in breakdowns)
-            u["total_rgu_h"] = total_rgu_h
-            u["total_wasted"] = total_wasted
-            u["total_true_wasted"] = total_rgu_h - sum(
-                c.rgu_hours_used for c in breakdowns
+
+            usage_data.rgu_hours = sum(c.rgu_hours for c in breakdowns)
+            usage_data.rgu_hours_used = sum(c.rgu_hours_used for c in breakdowns)
+            usage_data.wasted = sum(c.wasted for c in breakdowns)
+
+            usage_data.by_cluster = sorted(
+                u["clusters"], key=lambda c: c.wasted, reverse=True
             )
-            waste_ratio = total_wasted / total_rgu_h if total_rgu_h > 0 else 0.0
-            u["waste_ratio"] = waste_ratio
-            if waste_ratio >= min_waste_ratio and total_wasted >= min_waste_rgu_hours:
-                underuser_ids.append(uid)
+
+            if not usage_filter(usage_data):
+                user_data.pop(uid)
 
         # Per-job data for the identified underusers — same RGU × utilisation
         # pattern.
-        jobs_by_user: dict[int, list[UsageJob]] = {uid: [] for uid in underuser_ids}
-        if top_jobs_per_user > 0 and jobs_by_user:
+        jobs_by_user: dict[int, list[UsageJob]] = {uid: [] for uid in user_data.keys()}
+        if fetch_jobs_per_user and jobs_by_user:
             job_rows = session.exec(
                 _select_user_jobs(
-                    underuser_ids,
+                    list(jobs_by_user.keys()),
                     start,
                     end,
                     clusters=clusters,
@@ -406,7 +398,7 @@ def get_underusers(
             for jr in job_rows:
                 uid = jr.sarc_user_id
                 rgu_h = float(jr.rgu_hours or 0.0)
-                rgu_h_credited_used = float(jr.rgu_used or 0.0)
+                rgu_used_h = float(jr.rgu_used or 0.0)
                 gpu_sm_occupancy = _job_occupancy(
                     jr.allocated_gpu_cost, jr.allocated_gpu_waste
                 )
@@ -415,137 +407,80 @@ def get_underusers(
                         job_id=jr.job_db_id,
                         cluster=jr.cluster_name or "unknown",
                         submit_time=jr.submit_time,
-                        wasted=rgu_h - rgu_h_credited_used,
-                        rgu_hours_used=None,
+                        wasted=rgu_h - rgu_used_h,
+                        rgu_hours_used=rgu_used_h,
                         gpu_sm_occupancy=gpu_sm_occupancy,
                     )
                 )
 
     result = []
-    for uid in underuser_ids:
-        u = user_data[uid]
-        total_rgu_h = u["total_rgu_h"]
-        total_wasted = u["total_wasted"]
-        waste_ratio = u["waste_ratio"]
-
-        by_cluster = sorted(u["clusters"], key=lambda c: c.wasted, reverse=True)
-
-        top_jobs = sorted(
-            jobs_by_user[uid], key=lambda j: j.wasted, reverse=True
-        )[  # ty:ignore[no-matching-overload]
-            :top_jobs_per_user
-        ]
-
-        total_true_wasted = u["total_true_wasted"]
-        result.append(
-            UnderuserRow(
-                email=u["email"],
-                display_name=u["display_name"],
-                user_id=uid,
-                rgu_hours=total_rgu_h,
-                wasted=total_wasted,
-                waste_ratio=waste_ratio,
-                true_wasted=total_true_wasted,
-                true_waste_ratio=total_true_wasted / total_rgu_h
-                if total_rgu_h > 0
-                else 0.0,
-                by_cluster=by_cluster,
-                top_jobs=top_jobs,
-            )
-        )
+    for uid, u in user_data.items():
+        usage_data: UsageRow = u["usage_data"]
+        usage_data.top_jobs = jobs_by_user[uid]
+        result.append(usage_data)
 
     return result
 
 
-def get_all_users_usage(
+def get_underusers_usage(
+    start: datetime,
+    end: datetime,
+    *,
+    min_waste_ratio: float,
+    min_waste_rgu_hours: float,
+    top_jobs_per_user: int = 5,
+    clusters: list[str] | None = None,
+    utilization_ceiling: float = 1.0,
+    user_emails: list[str] | None = None,
+) -> list[UsageRow]:
+    # Filter users who don't meet both threshold conditions: their cross-cluster
+    # aggregated waste ratio and total wasted RGU-hours exceed `min_waste_ratio`
+    # and `min_waste_rgu_hours` respectively.
+    def filter_underusers(row: UsageRow):
+        return row.waste_ratio >= min_waste_ratio and row.wasted >= min_waste_rgu_hours
+
+    result = _get_users_usage(
+        start,
+        end,
+        usage_filter=filter_underusers,
+        fetch_jobs_per_user=top_jobs_per_user > 0,
+        clusters=clusters,
+        utilization_ceiling=utilization_ceiling,
+        user_emails=user_emails,
+    )
+
+    for row in result:
+        row.top_jobs.sort(key=lambda j: j.wasted, reverse=True)
+        row.top_jobs = row.top_jobs[:top_jobs_per_user]
+
+    return result
+
+
+def get_users_usage(
     start: datetime,
     end: datetime,
     *,
     min_usage_rgu_hours: float = 0.0,
-    top_jobs_per_user: int,
+    top_jobs_per_user: int = 5,
     clusters: list[str] | None = None,
     user_emails: list[str] | None = None,
 ) -> list[UsageRow]:
-    with config.db.session() as session:
-        stmt = _select_jobs_usage(
-            None,
-            start,
-            end,
-            by_cluster=True,
-            clusters=clusters,
-            user_emails=user_emails,
-        )
-        agg_rows = session.exec(stmt).all()
+    def filter_users(row: UsageRow):
+        return row.rgu_hours >= min_usage_rgu_hours
 
-        user_data: dict[int, dict] = {}
-        for row in agg_rows:
-            uid = row.sarc_user_id
-            if uid not in user_data:
-                user_data[uid] = {
-                    "email": row.email,
-                    "display_name": row.display_name,
-                    "clusters": [],
-                }
-            rgu_h, rgu_h_true_used, rgu_h_wasted = _split_waste(row)
-            user_data[uid]["clusters"].append(
-                UsageClusterBreakdown(
-                    cluster=row.cluster_name or "unknown",
-                    rgu_hours=rgu_h,
-                    rgu_hours_used=rgu_h_true_used,
-                    wasted=rgu_h_wasted,
-                )
-            )
+    result = _get_users_usage(
+        start,
+        end,
+        usage_filter=filter_users,
+        fetch_jobs_per_user=top_jobs_per_user > 0,
+        clusters=clusters,
+        user_emails=user_emails,
+    )
 
-        all_user_ids = list(user_data.keys())
-
-        jobs_by_user: dict[int, list[UsageJob]] = {uid: [] for uid in all_user_ids}
-        if top_jobs_per_user > 0 and all_user_ids:
-            job_rows = session.exec(
-                _select_user_jobs(all_user_ids, start, end, clusters)
-            ).all()
-
-            for jr in job_rows:
-                uid = jr.sarc_user_id
-                rgu_used_h = float(jr.rgu_used or 0.0)
-                jobs_by_user[uid].append(
-                    UsageJob(
-                        job_id=jr.job_db_id,
-                        cluster=jr.cluster_name or "unknown",
-                        submit_time=jr.submit_time,
-                        wasted=None,
-                        rgu_hours_used=rgu_used_h,
-                        gpu_sm_occupancy=_job_occupancy(
-                            jr.allocated_gpu_cost, jr.allocated_gpu_waste
-                        ),
-                    )
-                )
-
-    result = []
-    for uid, u in user_data.items():
-        breakdowns = u["clusters"]
-        total_rgu_h = sum(c.rgu_hours for c in breakdowns)
-        total_used = sum(c.rgu_hours_used for c in breakdowns)
-        if total_rgu_h <= min_usage_rgu_hours:
-            continue
-
-        by_cluster = sorted(breakdowns, key=lambda c: c.rgu_hours_used, reverse=True)
-        # Sorted by GPU utilization (not usage volume) so these are honestly
-        # the user's *most efficient* jobs, per the usage report's framing.
-        top_jobs = sorted(
-            jobs_by_user[uid], key=lambda j: j.gpu_sm_occupancy, reverse=True
-        )[:top_jobs_per_user]
-
-        result.append(
-            UsageRow(
-                email=u["email"],
-                display_name=u["display_name"],
-                user_id=uid,
-                rgu_hours=total_rgu_h,
-                rgu_hours_used=total_used,
-                by_cluster=by_cluster,
-                top_jobs=top_jobs,
-            )
-        )
+    # Sorted by GPU utilization so these are the user's *most efficient* jobs
+    for row in result:
+        row.top_jobs.sort(key=lambda j: j.gpu_sm_occupancy, reverse=True)
+        row.top_jobs = row.top_jobs[:top_jobs_per_user]
 
     return result
 
@@ -709,7 +644,7 @@ def get_recurring_underusers(
     membership_results = _run_concurrently(
         [
             partial(
-                get_underusers,
+                get_underusers_usage,
                 c_start,
                 c_end,
                 min_waste_ratio=min_waste_ratio,

--- a/sarc/notifications/underusage.py
+++ b/sarc/notifications/underusage.py
@@ -1,12 +1,53 @@
+import contextvars
+from collections.abc import Callable, Sequence
+from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass, field
 from datetime import date, datetime, timedelta
-from functools import cached_property
+from functools import cached_property, partial
+from typing import TypeVar
 
 from sqlmodel import col, func, select
 
 from sarc.api.metrics import _is_real
 from sarc.config import config
 from sarc.db.job_series import JobSeriesDB
+
+_MAX_WORKERS = 4
+
+T = TypeVar("T")
+
+
+def _run_concurrently(tasks: Sequence[Callable[[], T]]) -> list[T]:
+    # Order-preserving: results match the order of `tasks`, not completion
+    # order. On any task exception, that exception propagates from
+    # .result(), but only after every already-dispatched task has finished
+    # (ThreadPoolExecutor's __exit__ waits for all of them; there's no cheap
+    # way to cancel already-running threads) -- fine for a handful of
+    # iterations with no external SLA.
+    #
+    # Each task gets its own contextvars.copy_context() rather than one
+    # shared copy: gifnoc's active-configuration overlay (set via `with
+    # gifnoc.overlay(...):`) lives in a ContextVar, which a fresh worker
+    # thread won't see unless the context is copied in explicitly -- and a
+    # single Context object can't be entered concurrently by more than one
+    # thread, so reusing one copy across submissions raises
+    # "RuntimeError: cannot enter context" as soon as two tasks overlap.
+    if not tasks:
+        return []
+
+    def _run_in_context(ctx: contextvars.Context, task: Callable[[], T]) -> T:
+        return ctx.run(task)
+
+    with ThreadPoolExecutor(max_workers=_MAX_WORKERS) as executor:
+        # contextvars.copy_context() is called here, in the submitting
+        # thread, for each task -- NOT inside _run_in_context, which runs on
+        # the worker thread and would otherwise copy that (uninitialized)
+        # worker context instead of this thread's overlaid one.
+        futures: list[Future[T]] = [
+            executor.submit(_run_in_context, contextvars.copy_context(), task)
+            for task in tasks
+        ]
+        return [f.result() for f in futures]
 
 
 def usage_cycle_length_weeks():
@@ -543,6 +584,31 @@ def get_cycle_dates(end: datetime, n: int = 5) -> list[date]:
     return [(anchor - timedelta(weeks=i * cycle_length_weeks)).date() for i in range(n)]
 
 
+def _fetch_pa_window_rows(
+    user_ids: list[int],
+    pa_start: datetime,
+    pa_end: datetime,
+    i: int,
+    clusters: list[str] | None,
+    utilization_ceiling: float,
+):
+    """One position's personalized-action rolling-window query, run inside
+    `get_recurring_underusers`'s capped thread pool -- opens its own session
+    rather than sharing one, since sessions aren't thread-safe. Module-level
+    (not a nested closure) so it's directly monkeypatch-able from tests.
+    """
+    with config.db.session() as session:
+        pa_stmt = _select_jobs_usage(
+            user_ids,
+            pa_start,
+            pa_end,
+            by_cluster=False,
+            clusters=clusters,
+            utilization_ceiling=utilization_ceiling,
+        )
+        return i, session.exec(pa_stmt).all()
+
+
 def get_recurring_underusers(
     end: datetime,
     *,
@@ -628,61 +694,82 @@ def get_recurring_underusers(
 
     # ── Cycle membership sets ─────────────────────────────────────────────────
     # Each cycle ends at anchor - i*cycle_length_weeks (always aligned). Cycles
-    # whose end is in the future relative to `end` yield None (no data).
-    cycle_flagged: list[set[int] | None] = []
+    # whose end is in the future relative to `end` yield None (no data). Each
+    # position's get_underusers call is independent of every other, so they
+    # run on a small capped thread pool instead of one after another.
+    cycle_flagged: list[set[int] | None] = [None] * recurrence_display_cycles
+    active_cycles: list[tuple[int, datetime, datetime]] = []
     for i in range(recurrence_display_cycles):
         c_end = anchor - timedelta(weeks=i * cycle_length_weeks)
         if c_end > end:
-            cycle_flagged.append(None)
             continue
         c_start = c_end - timedelta(weeks=cycle_length_weeks)
-        flagged_rows = get_underusers(
-            c_start,
-            c_end,
-            min_waste_ratio=min_waste_ratio,
-            min_waste_rgu_hours=min_waste_rgu_hours,
-            # Only user_id is used for membership — top jobs are discarded.
-            top_jobs_per_user=0,
-            clusters=clusters,
-            utilization_ceiling=utilization_ceiling,
-        )
-        cycle_flagged.append({r.user_id for r in flagged_rows})
+        active_cycles.append((i, c_start, c_end))
+
+    membership_results = _run_concurrently(
+        [
+            partial(
+                get_underusers,
+                c_start,
+                c_end,
+                min_waste_ratio=min_waste_ratio,
+                min_waste_rgu_hours=min_waste_rgu_hours,
+                # Only user_id is used for membership — top jobs are discarded.
+                top_jobs_per_user=0,
+                clusters=clusters,
+                utilization_ceiling=utilization_ceiling,
+            )
+            for _, c_start, c_end in active_cycles
+        ]
+    )
+    for (i, _, _), flagged_rows in zip(active_cycles, membership_results):
+        cycle_flagged[i] = {r.user_id for r in flagged_rows}
 
     # ── Personalized-action aggregate (per active anchor, cross-cluster) ──────
     # For position i, the window is [anchor − (i+active_cycles)·cl, anchor −
     # i·cl]. Index 0 = most-recent anchor (matches the former single-window
-    # query).
+    # query). Same independence-per-position as above, so also run concurrently
+    # — each position opens its own session (_fetch_pa_window_rows) rather than
+    # sharing one across positions.
     user_ids = list({uid for uids in cluster_users.values() for uid in uids})
     pa_window_weeks = recurrence_active_cycles * cycle_length_weeks
-    user_pa_flags: dict[int, list[bool]] = {}
-    with config.db.session() as session:
-        for i in range(recurrence_display_cycles):
-            # PA at position i requires both the waste floor and single-cycle
-            # underuse in that position's most-recent cycle. cycle_flagged[i] is
-            # None for a cycle ending in the future (guarded before membership).
-            if cycle_flagged[i] is None:
-                continue
-            _this_cycle_flagged: set[int] = cycle_flagged[i] or set()
+    active_pa_positions: list[tuple[int, datetime, datetime]] = []
+    for i in range(recurrence_display_cycles):
+        if cycle_flagged[i] is None:
+            continue
+        pa_end = anchor - timedelta(weeks=i * cycle_length_weeks)
+        pa_start = pa_end - timedelta(weeks=pa_window_weeks)
+        active_pa_positions.append((i, pa_start, pa_end))
 
-            pa_end = anchor - timedelta(weeks=i * cycle_length_weeks)
-            pa_start = pa_end - timedelta(weeks=pa_window_weeks)
-            pa_stmt = _select_jobs_usage(
+    pa_results = _run_concurrently(
+        [
+            partial(
+                _fetch_pa_window_rows,
                 user_ids,
                 pa_start,
                 pa_end,
-                by_cluster=False,
-                clusters=clusters,
-                utilization_ceiling=utilization_ceiling,
+                i,
+                clusters,
+                utilization_ceiling,
             )
-            for row in session.exec(pa_stmt).all():
-                uid = row.sarc_user_id
-                if uid not in user_pa_flags:
-                    user_pa_flags[uid] = [False] * recurrence_display_cycles
-                _, _, pa_rgu_wasted_h = _split_waste(row)
-                user_pa_flags[uid][i] = (
-                    pa_rgu_wasted_h >= personalized_action_min_waste_rgu_hours
-                    and uid in _this_cycle_flagged
-                )
+            for i, pa_start, pa_end in active_pa_positions
+        ]
+    )
+
+    user_pa_flags: dict[int, list[bool]] = {}
+    for i, rows in pa_results:
+        # PA at position i requires both the waste floor and single-cycle
+        # underuse in that position's most-recent cycle.
+        _this_cycle_flagged: set[int] = cycle_flagged[i] or set()
+        for row in rows:
+            uid = row.sarc_user_id
+            if uid not in user_pa_flags:
+                user_pa_flags[uid] = [False] * recurrence_display_cycles
+            _, _, pa_rgu_wasted_h = _split_waste(row)
+            user_pa_flags[uid][i] = (
+                pa_rgu_wasted_h >= personalized_action_min_waste_rgu_hours
+                and uid in _this_cycle_flagged
+            )
 
     # ── Per-cluster greedy selection (cumulative share >= cluster_share_threshold) ──
     result: dict[str, list[RecurringUserRow]] = {}

--- a/tests/unittests/notifications/test_cli.py
+++ b/tests/unittests/notifications/test_cli.py
@@ -12,12 +12,12 @@ from sarc.db.cluster import SlurmClusterDB
 from sarc.db.users import UserDB
 from sarc.notifications.slack import SendResult, SendStatus
 from sarc.notifications.underusage import (
-    get_all_users_usage as _real_get_all_users_usage,
-)
-from sarc.notifications.underusage import (
     get_recurring_underusers as _real_get_recurring_underusers,
 )
-from sarc.notifications.underusage import get_underusers as _real_get_underusers
+from sarc.notifications.underusage import (
+    get_underusers_usage as _real_get_underusers_usage,
+)
+from sarc.notifications.underusage import get_users_usage as _real_get_users_usage
 from tests.unittests.notifications._factory import (
     UNDERUSAGE_REPORT_TEMPLATE,
     USAGE_REPORT_TEMPLATE,
@@ -694,8 +694,8 @@ def test_no_dms_flag_suppresses_usage_report_sends(
 def test_min_waste_ratio_flag_overrides_config(
     notify_db, cli_main, monkeypatch, capsys
 ):
-    spy = MagicMock(wraps=_real_get_underusers)
-    monkeypatch.setattr("sarc.cli.notify.underusage.get_underusers", spy)
+    spy = MagicMock(wraps=_real_get_underusers_usage)
+    monkeypatch.setattr("sarc.cli.notify.underusage.get_underusers_usage", spy)
 
     with gifnoc.overlay({"sarc.notifications": _NOTIFY_CFG}):
         rc = cli_main(["notify", "underusage", "--as-of", _CYCLE_WEEK])
@@ -723,11 +723,11 @@ def test_min_waste_ratio_flag_overrides_config(
 def test_min_waste_ratio_flag_explicit_zero_is_honored(
     notify_db, cli_main, monkeypatch
 ):
-    """An explicit --min-waste-ratio 0 must reach get_underusers as 0.0, not be
+    """An explicit --min-waste-ratio 0 must reach get_underusers_usage as 0.0, not be
     silently dropped in favor of the config default (0.0 is falsy in Python, so
     a naive `if self.min_waste_ratio:` check would incorrectly ignore it)."""
-    spy = MagicMock(wraps=_real_get_underusers)
-    monkeypatch.setattr("sarc.cli.notify.underusage.get_underusers", spy)
+    spy = MagicMock(wraps=_real_get_underusers_usage)
+    monkeypatch.setattr("sarc.cli.notify.underusage.get_underusers_usage", spy)
 
     with gifnoc.overlay({"sarc.notifications": _NOTIFY_CFG}):
         rc = cli_main(
@@ -780,8 +780,8 @@ def test_user_email_flag_logs_warning(notify_db, cli_main, caplog):
 def test_min_waste_rgu_hours_flag_overrides_config(
     notify_db, cli_main, monkeypatch, capsys
 ):
-    spy = MagicMock(wraps=_real_get_underusers)
-    monkeypatch.setattr("sarc.cli.notify.underusage.get_underusers", spy)
+    spy = MagicMock(wraps=_real_get_underusers_usage)
+    monkeypatch.setattr("sarc.cli.notify.underusage.get_underusers_usage", spy)
 
     # Each seeded user wastes 4.8 * 700 * 0.9 = 3024 RGU-h — a 5000 override excludes them all.
     with gifnoc.overlay({"sarc.notifications": _NOTIFY_CFG}):
@@ -803,8 +803,8 @@ def test_min_waste_rgu_hours_flag_overrides_config(
 def test_usage_report_min_usage_rgu_hours_flag_overrides_config(
     usage_report_db, cli_main, monkeypatch, capsys
 ):
-    spy = MagicMock(wraps=_real_get_all_users_usage)
-    monkeypatch.setattr("sarc.cli.notify.underusage.get_all_users_usage", spy)
+    spy = MagicMock(wraps=_real_get_users_usage)
+    monkeypatch.setattr("sarc.cli.notify.underusage.get_users_usage", spy)
 
     with gifnoc.overlay({"sarc.notifications": _NOTIFY_CFG}):
         rc = cli_main(["notify", "underusage", "--as-of", _USAGE_REPORT_WEEK])
@@ -838,8 +838,8 @@ def test_usage_report_not_email_filtered_when_no_underusers(
     usage-report query must receive user_emails=None (no filter). Passing an
     empty list instead makes _select_jobs_usage filter `email IN ()`, matching
     nobody — silently emptying the fleet-wide usage report."""
-    spy = MagicMock(wraps=_real_get_all_users_usage)
-    monkeypatch.setattr("sarc.cli.notify.underusage.get_all_users_usage", spy)
+    spy = MagicMock(wraps=_real_get_users_usage)
+    monkeypatch.setattr("sarc.cli.notify.underusage.get_users_usage", spy)
 
     # An impossible waste-ratio floor means nobody qualifies as an underuser
     # this cycle, while the usage report is still eligible.

--- a/tests/unittests/notifications/test_messages.py
+++ b/tests/unittests/notifications/test_messages.py
@@ -17,7 +17,6 @@ from sarc.notifications.messages import (
 from sarc.notifications.slack import MENTION_TOKEN
 from sarc.notifications.underusage import (
     RecurringUserRow,
-    UnderuserRow,
     UsageClusterBreakdown,
     UsageJob,
     UsageRow,
@@ -196,13 +195,12 @@ _JOB_FIR = UsageJob(
     gpu_sm_occupancy=None,
 )
 
-_ROW_ALICE = UnderuserRow(
+_ROW_ALICE = UsageRow(
     email="alice@mila.quebec",
     display_name="Alice Liddell",
     user_id=1,
     rgu_hours=1000.0,
     wasted=255.0,
-    waste_ratio=0.255,
     by_cluster=[
         UsageClusterBreakdown("narval", 700.0, 490.0, 700.0 - 490.0),
         UsageClusterBreakdown("fir", 300.0, 255.0, 300.0 - 255.0),
@@ -210,24 +208,22 @@ _ROW_ALICE = UnderuserRow(
     top_jobs=[_JOB_NARVAL_1, _JOB_NARVAL_2, _JOB_FIR],
 )
 
-_ROW_BOB = UnderuserRow(
+_ROW_BOB = UsageRow(
     email="bob@mila.quebec",
     display_name="Bob Marley",
     user_id=2,
     rgu_hours=800.0,
     wasted=600.0,
-    waste_ratio=0.75,
     by_cluster=[UsageClusterBreakdown("fir", 800.0, 200.0, 800.0 - 200.0)],
     top_jobs=[],
 )
 
-_ROW_CAROL = UnderuserRow(
+_ROW_CAROL = UsageRow(
     email="carol@mila.quebec",
     display_name="Carol Danvers",
     user_id=3,
     rgu_hours=700.0,
     wasted=420.0,
-    waste_ratio=0.60,
     by_cluster=[UsageClusterBreakdown("mila", 700.0, 280.0, 700.0 - 280.0)],
     top_jobs=[],
 )

--- a/tests/unittests/notifications/test_underusage.py
+++ b/tests/unittests/notifications/test_underusage.py
@@ -19,8 +19,8 @@ from sarc.db.users import UserDB
 from sarc.notifications.underusage import (
     _run_concurrently,
     _select_user_jobs,
-    get_all_users_usage,
-    get_underusers,
+    get_underusers_usage,
+    get_users_usage,
 )
 from tests.unittests.notifications._factory import add_gpu_job
 
@@ -152,7 +152,7 @@ def underusage_db(read_write_db):
 
 
 def test_underusers_filtering_and_top_jobs(underusage_db):
-    results = get_underusers(
+    results = get_underusers_usage(
         _WINDOW_START,
         _WINDOW_END,
         min_waste_ratio=_MIN_WASTE_RATIO,
@@ -187,7 +187,7 @@ def test_underusers_filtering_and_top_jobs(underusage_db):
 
 
 def test_underusers_overview_fields(underusage_db):
-    results = get_underusers(
+    results = get_underusers_usage(
         _WINDOW_START,
         _WINDOW_END,
         min_waste_ratio=0.0,
@@ -211,7 +211,7 @@ def test_outside_window_excluded(underusage_db):
     before = datetime(2020, 1, 1, tzinfo=UTC)
     after = datetime(2020, 12, 31, tzinfo=UTC)
     assert (
-        get_underusers(
+        get_underusers_usage(
             before,
             after,
             min_waste_ratio=0.0,
@@ -254,7 +254,7 @@ def test_run_concurrently_empty_tasks_returns_empty_list():
 
 def test_usage_all_users_overview_and_top_jobs(underusage_db):
     # All 3 users have GPU jobs in the window — no threshold filtering.
-    results = get_all_users_usage(
+    results = get_users_usage(
         _WINDOW_START, _WINDOW_END, top_jobs_per_user=_TOP_JOBS_PER_USER
     )
     emails = {r.email for r in results}
@@ -282,9 +282,7 @@ def test_usage_all_users_overview_and_top_jobs(underusage_db):
 def test_usage_outside_window_excluded(underusage_db):
     before = datetime(2020, 1, 1, tzinfo=UTC)
     after = datetime(2020, 12, 31, tzinfo=UTC)
-    assert (
-        get_all_users_usage(before, after, top_jobs_per_user=_TOP_JOBS_PER_USER) == []
-    )
+    assert get_users_usage(before, after, top_jobs_per_user=_TOP_JOBS_PER_USER) == []
 
 
 # ── top_jobs_per_user is config-driven ───────────────────────────────────────
@@ -292,7 +290,7 @@ def test_usage_outside_window_excluded(underusage_db):
 
 def test_top_jobs_per_user_3(underusage_db):
     # petitbonhomme has >5 jobs; verify the cap follows the param.
-    results = get_underusers(
+    results = get_underusers_usage(
         _WINDOW_START,
         _WINDOW_END,
         min_waste_ratio=_MIN_WASTE_RATIO,
@@ -305,7 +303,7 @@ def test_top_jobs_per_user_3(underusage_db):
 
 def test_usage_top_jobs_per_user_3(underusage_db):
     # petitbonhomme has 9 jobs total; verify the cap follows the param.
-    results = get_all_users_usage(_WINDOW_START, _WINDOW_END, top_jobs_per_user=3)
+    results = get_users_usage(_WINDOW_START, _WINDOW_END, top_jobs_per_user=3)
     row = next(r for r in results if r.email == "petitbonhomme@mila.quebec")
     assert len(row.top_jobs) == 3
 
@@ -315,7 +313,7 @@ def test_usage_top_jobs_per_user_3(underusage_db):
 
 def test_clusters_filter_excludes_other_clusters(underusage_db):
     # petitbonhomme has jobs on both mila and raisin; restrict to mila only.
-    results = get_underusers(
+    results = get_underusers_usage(
         _WINDOW_START,
         _WINDOW_END,
         min_waste_ratio=_MIN_WASTE_RATIO,
@@ -331,7 +329,7 @@ def test_clusters_filter_excludes_other_clusters(underusage_db):
 
 
 def test_get_underusers_user_emails_filters_to_single_user(underusage_db):
-    results = get_underusers(
+    results = get_underusers_usage(
         _WINDOW_START,
         _WINDOW_END,
         min_waste_ratio=0.0,
@@ -350,14 +348,16 @@ def test_get_underusers_user_emails_none_matches_default(underusage_db):
         min_waste_rgu_hours=0.0,
         top_jobs_per_user=_TOP_JOBS_PER_USER,
     )
-    with_none = get_underusers(_WINDOW_START, _WINDOW_END, user_emails=None, **kwargs)
-    without_kwarg = get_underusers(_WINDOW_START, _WINDOW_END, **kwargs)
+    with_none = get_underusers_usage(
+        _WINDOW_START, _WINDOW_END, user_emails=None, **kwargs
+    )
+    without_kwarg = get_underusers_usage(_WINDOW_START, _WINDOW_END, **kwargs)
     assert {r.email for r in with_none} == {r.email for r in without_kwarg}
 
 
 def test_get_underusers_user_emails_empty_list_returns_no_rows(underusage_db):
     """user_emails=[] is a real (non-matching) filter, unlike user_emails=None."""
-    results = get_underusers(
+    results = get_underusers_usage(
         _WINDOW_START,
         _WINDOW_END,
         min_waste_ratio=0.0,
@@ -369,7 +369,7 @@ def test_get_underusers_user_emails_empty_list_returns_no_rows(underusage_db):
 
 
 def test_get_all_users_usage_user_emails_filters_to_single_user(underusage_db):
-    results = get_all_users_usage(
+    results = get_users_usage(
         _WINDOW_START,
         _WINDOW_END,
         top_jobs_per_user=_TOP_JOBS_PER_USER,
@@ -379,7 +379,7 @@ def test_get_all_users_usage_user_emails_filters_to_single_user(underusage_db):
 
 
 def test_get_all_users_usage_user_emails_none_returns_all(underusage_db):
-    results = get_all_users_usage(
+    results = get_users_usage(
         _WINDOW_START,
         _WINDOW_END,
         top_jobs_per_user=_TOP_JOBS_PER_USER,
@@ -397,7 +397,7 @@ def test_get_all_users_usage_exclusion_only_list_does_not_match_nobody(underusag
     """user_emails=["~x"] (exclusion-only, no allow-list entries) must not be
     treated the same as an explicit empty allow-list — it should return every
     other user, only excluding x."""
-    results = get_all_users_usage(
+    results = get_users_usage(
         _WINDOW_START,
         _WINDOW_END,
         top_jobs_per_user=_TOP_JOBS_PER_USER,
@@ -412,7 +412,7 @@ def test_get_all_users_usage_exclusion_only_list_does_not_match_nobody(underusag
 
 def test_true_wasted_field_at_identity(underusage_db):
     # At threshold=1.0, true_wasted must equal wasted on every row.
-    results = get_underusers(
+    results = get_underusers_usage(
         _WINDOW_START,
         _WINDOW_END,
         min_waste_ratio=0.0,
@@ -432,7 +432,7 @@ def test_scaled_waste_less_than_true_waste_below_threshold(underusage_db):
     # credited_used = LEAST(rgu_h, rgu_h*(1-0.80+0.10)) = rgu_h*0.30  → wasted=70%
     # true_used = rgu_h*0.10  → true_wasted=90%
     # So scaled waste < true waste.
-    results = get_underusers(
+    results = get_underusers_usage(
         _WINDOW_START,
         _WINDOW_END,
         min_waste_ratio=_MIN_WASTE_RATIO,
@@ -449,7 +449,7 @@ def test_subtractive_formula_exact_waste_ratio(underusage_db):
     # Petitbonhomme total: rgu_h=12800 (mila 4800 + raisin 8000).
     # Subtractive waste per job = rgu_h * max(0, T - m).
     # At T=0.80: sum(waste) = 9592 → waste_ratio = 9592/12800.
-    results = get_underusers(
+    results = get_underusers_usage(
         _WINDOW_START,
         _WINDOW_END,
         min_waste_ratio=_MIN_WASTE_RATIO,
@@ -462,7 +462,7 @@ def test_subtractive_formula_exact_waste_ratio(underusage_db):
 
     # At T=0.20: sum(waste) = 1984 → waste_ratio = 1984/12800 < _MIN_WASTE_RATIO;
     # pass min_waste_ratio=0.10 so petitbonhomme still appears.
-    results = get_underusers(
+    results = get_underusers_usage(
         _WINDOW_START,
         _WINDOW_END,
         min_waste_ratio=0.10,
@@ -478,7 +478,7 @@ def test_subtractive_formula_boundary_zero_waste(underusage_db):
     # Beaubonhomme: single mila job, m=0.80, rgu_h=3360.
     # Subtractive: waste_ratio = max(0, T - m). Allocation-independent.
     # At T=0.80: m == T → waste = 0.
-    results = get_underusers(
+    results = get_underusers_usage(
         _WINDOW_START,
         _WINDOW_END,
         min_waste_ratio=0.0,
@@ -490,7 +490,7 @@ def test_subtractive_formula_boundary_zero_waste(underusage_db):
     assert row.wasted == pytest.approx(0.0, abs=1e-6)
 
     # At T=0.90: waste_ratio = 0.90 - 0.80 = 0.10 exactly.
-    results = get_underusers(
+    results = get_underusers_usage(
         _WINDOW_START,
         _WINDOW_END,
         min_waste_ratio=0.05,
@@ -506,7 +506,7 @@ def test_top_job_gpu_sm_occupancy_is_raw_mean(underusage_db):
     # At T=0.80, displayed gpu_sm_occupancy must be raw m, independent of T.
     # Raisin job m=0.0: shows 0.0. Mila top job m=0.10: shows 0.10 (not 0.125 =
     # 0.10/0.80).
-    results = get_underusers(
+    results = get_underusers_usage(
         _WINDOW_START,
         _WINDOW_END,
         min_waste_ratio=_MIN_WASTE_RATIO,
@@ -526,7 +526,7 @@ def test_top_job_gpu_sm_occupancy_is_raw_mean(underusage_db):
 
 def test_usage_floor_excludes_below_threshold(underusage_db):
     # bramin: 100h * 4.8 rgu = 480 rgu_h total_requested → below 500 floor → excluded
-    results = get_all_users_usage(
+    results = get_users_usage(
         _WINDOW_START,
         _WINDOW_END,
         top_jobs_per_user=_TOP_JOBS_PER_USER,
@@ -539,7 +539,7 @@ def test_usage_floor_excludes_below_threshold(underusage_db):
 
 def test_usage_floor_at_boundary_is_excluded(underusage_db):
     # bramin ≈ 480 rgu_h; floor=481 is just above → excluded
-    results = get_all_users_usage(
+    results = get_users_usage(
         _WINDOW_START,
         _WINDOW_END,
         top_jobs_per_user=_TOP_JOBS_PER_USER,
@@ -575,7 +575,7 @@ def missing_util_db(read_write_db):
 
 
 def test_missing_util_not_flagged(missing_util_db):
-    results = get_underusers(
+    results = get_underusers_usage(
         _WINDOW_START,
         _WINDOW_END,
         min_waste_ratio=_MIN_WASTE_RATIO,
@@ -589,7 +589,7 @@ def test_missing_util_zero_waste(missing_util_db):
     # bramin's only job has no gpu_sm_occupancy stat, so it's excluded
     # entirely upstream — he produces no aggregate row at all, even at
     # zero-value thresholds.
-    results = get_underusers(
+    results = get_underusers_usage(
         _WINDOW_START,
         _WINDOW_END,
         min_waste_ratio=0.0,
@@ -603,7 +603,7 @@ def test_missing_util_non_negative_waste_at_sub_threshold(missing_util_db):
     # Regression guard: at a sub-1.0 ceiling, bramin's no-stat job must still
     # be excluded upstream rather than entering the subtractive ceiling
     # formula (which would otherwise propagate NaN into an undefined waste).
-    results = get_underusers(
+    results = get_underusers_usage(
         _WINDOW_START,
         _WINDOW_END,
         min_waste_ratio=0.0,
@@ -618,7 +618,7 @@ def test_missing_util_usage_rgu_hours_used_equals_requested(missing_util_db):
     # bramin's only job is excluded from the SQL aggregate entirely (no
     # gpu_sm_occupancy stat), so he never produces a user_data entry and
     # never reaches get_all_users_usage's usage-floor check at all.
-    results = get_all_users_usage(
+    results = get_users_usage(
         _WINDOW_START, _WINDOW_END, top_jobs_per_user=_TOP_JOBS_PER_USER
     )
     assert "bramin@mila.quebec" not in {r.email for r in results}
@@ -654,7 +654,7 @@ def test_zero_cost_job_does_not_crash(zero_cost_db):
     # Regression: total_rgu_h == 0 for this user must not raise ZeroDivisionError
     # in the waste_ratio computation (which runs before the floor check), and the
     # user must be excluded (waste == 0 fails the min_waste_rgu_hours floor).
-    results = get_underusers(
+    results = get_underusers_usage(
         _WINDOW_START,
         _WINDOW_END,
         min_waste_ratio=_MIN_WASTE_RATIO,

--- a/tests/unittests/notifications/test_underusage.py
+++ b/tests/unittests/notifications/test_underusage.py
@@ -17,6 +17,7 @@ from sarc.db.cluster import SlurmClusterDB
 from sarc.db.support import GpuRguDB
 from sarc.db.users import UserDB
 from sarc.notifications.underusage import (
+    _run_concurrently,
     _select_user_jobs,
     get_all_users_usage,
     get_underusers,
@@ -238,6 +239,14 @@ def test_select_user_jobs_empty_list_returns_no_rows(underusage_db):
     """user_ids=[] is a real (non-matching) filter, unlike user_ids=None."""
     stmt = _select_user_jobs([], _WINDOW_START, _WINDOW_END)
     assert underusage_db.exec(stmt).all() == []
+
+
+# ── _run_concurrently ─────────────────────────────────────────────────────────
+
+
+def test_run_concurrently_empty_tasks_returns_empty_list():
+    """Empty task list short-circuits before spinning up the thread pool."""
+    assert _run_concurrently([]) == []
 
 
 # ── get_all_users_usage ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Speeds up `get_recurring_underusers` by running its independent per-cycle and per-window queries concurrently instead of sequentially, and simplifies the underlying usage-query code by merging `UnderuserRow`/`UsageRow` into one type and deduping the two usage-fetching functions onto a shared helper.

## Changes
- Added `_run_concurrently`, a small capped thread pool (max 4 workers) that copies each task's `contextvars.Context` so gifnoc's config overlay propagates correctly to worker threads.
- `get_recurring_underusers` now dispatches its per-cycle membership queries and per-window personalized-action queries through `_run_concurrently` instead of a sequential loop.
- Merged `UnderuserRow` into `UsageRow`; `waste_ratio`, `true_wasted`, and `true_waste_ratio` are now `cached_property`s computed from `rgu_hours`/`rgu_hours_used`/`wasted` instead of separately-passed fields.
- Extracted `_get_users_usage(..., usage_filter=...)` as the shared query core; `get_underusers` → `get_underusers_usage` and `get_all_users_usage` → `get_users_usage` are now thin wrappers with their own filter/sort logic.
- Updated call sites (`sarc/cli/notify/underusage.py`, `sarc/notifications/messages.py`) and tests for the renames and merged type.

## Notes
- Function renames (`get_underusers` → `get_underusers_usage`, `get_all_users_usage` → `get_users_usage`) and the `UnderuserRow` → `UsageRow` merge are internal API changes — no external callers outside this repo are expected, but worth flagging in review.
