### PR TITLE
Export recurring-underusers table as CSV on admin digest

### DIFF
--- a/config/sarc-ref.yaml
+++ b/config/sarc-ref.yaml
@@ -89,7 +89,7 @@ sarc:
       token: slack-token-replace-me # SENSITIVE: can be used to send messages on slack
       channel: slack-channel-id-replace-me # The slack channel ID to message
   notifications:
-    # Required bot scopes: chat:write, im:write, users:read.email
+    # Required bot scopes: chat:write, im:write, users:read.email, files:write
     slack_underusage: # Credentials for delivering user DMs and the admin digest
       description: Under Usage Reports # used to distinguish multiple instances if the message the same channel
       token: slack-token-replace-me # SENSITIVE: can be used to send messages on slack

--- a/sarc/cli/notify/usage.py
+++ b/sarc/cli/notify/usage.py
@@ -8,6 +8,7 @@ import gifnoc
 import simple_parsing
 
 from sarc.config import config
+from sarc.notifications.csv_export import build_recurring_distilled_csv
 from sarc.notifications.messages import (
     build_admin_digest,
     build_usage_report,
@@ -19,6 +20,7 @@ from sarc.notifications.usage import (
     get_recurring_underusers,
     get_underusers_usage,
     get_users_usage,
+    select_recurring_table_view,
 )
 
 logger = logging.getLogger(__name__)
@@ -352,20 +354,33 @@ class UsageNotifyCommand:
         # also the preview print and the later channel post) entirely — only the
         # per-user DM(s) above should go out.
         if self.user_email is None:
-            recurring = get_recurring_underusers(
+            # Wide/unfiltered pull: every underusing user per cluster (no
+            # cluster_share_threshold cutoff), history_cycles cycles. The Slack
+            # table's narrower view is derived from this same pull below —
+            # exact, not an approximation, since per-user waste/share and each
+            # cycle
+            # position's flags are independent of recurrence_display_cycles/
+            # cluster_share_threshold in the underlying aggregate.
+            csv_recurring = get_recurring_underusers(
                 end,
                 min_waste_ratio=ncfg.min_waste_ratio,
                 min_waste_rgu_hours=ncfg.min_waste_rgu_hours,
-                cluster_share_threshold=ncfg.recurrence_cluster_share,
-                recurrence_display_cycles=ncfg.recurrence_display_cycles,
+                recurrence_display_cycles=ncfg.history_cycles,
                 recurrence_active_cycles=ncfg.recurrence_active_cycles,
                 clusters=clusters,
                 utilization_ceiling=ncfg.utilization_ceiling,
                 personalized_action_min_waste_rgu_hours=ncfg.personalized_action_min_waste_rgu_hours,
                 ignore_store=ignore_store,
             )
+            recurring = select_recurring_table_view(
+                csv_recurring,
+                display_cycles=ncfg.recurrence_display_cycles,
+                cluster_share_threshold=ncfg.recurrence_cluster_share,
+            )
 
-            cycle_dates = get_cycle_dates(end, ncfg.recurrence_display_cycles)
+            cycle_dates = get_cycle_dates(end, ncfg.history_cycles)[
+                : ncfg.recurrence_display_cycles
+            ]
             digest = build_admin_digest(
                 underusage_rows,
                 period=period,
@@ -377,8 +392,10 @@ class UsageNotifyCommand:
             )
             _userfacing_print("=== Admin Digest ===")
             _userfacing_print(digest)
+
         else:
             digest = None
+            csv_recurring = None
 
         if not self.send:
             return 0
@@ -443,7 +460,7 @@ class UsageNotifyCommand:
             )
 
         channel_res = None
-        if digest is not None:
+        if digest is not None and csv_recurring is not None:
             channel_res = slack_underusage_client.post_channel(
                 ncfg.slack_underusage.channel, digest, preformatted=True
             )
@@ -452,6 +469,38 @@ class UsageNotifyCommand:
                     "Failed to post admin digest to %s: %s",
                     ncfg.slack_underusage.channel,
                     channel_res.detail,
+                )
+
+            # Recurring-underusers CSV export (full dataset, history_cycles
+            # cycles): a distilled close-copy of the Slack table, uploaded as a
+            # threaded reply. thread_ts is passed through even when
+            # channel_res.ts is None (digest post failed) — same
+            # degrade-to-non-threaded-post behavior the footer replies below
+            # already rely on.
+            assert ncfg.recurrence_active_cycles < ncfg.history_cycles, (
+                f"{ncfg.recurrence_active_cycles=} must be < {ncfg.history_cycles=}"
+            )
+            csv_cycle_dates = get_cycle_dates(end, ncfg.history_cycles)
+            window_end = csv_cycle_dates[0]
+            window_start = csv_cycle_dates[ncfg.recurrence_active_cycles]
+            distilled_csv = build_recurring_distilled_csv(
+                csv_recurring,
+                active_cycles=ncfg.recurrence_active_cycles,
+                cycle_dates=csv_cycle_dates,
+                dashboard_url=ncfg.dashboard_url,
+                window_start=window_start,
+                window_end=window_end,
+            )
+            upload_res = slack_underusage_client.upload_files(
+                ncfg.slack_underusage.channel,
+                [(f"recurring_underusers_distilled_{end.date()}.csv", distilled_csv)],
+                thread_ts=channel_res.ts,
+            )
+            if upload_res.status != SendStatus.OK:
+                logger.error(
+                    "Failed to upload recurring-underusers CSVs to %s: %s",
+                    ncfg.slack_underusage.channel,
+                    upload_res.detail,
                 )
 
             # Delivery summaries go in the digest's thread: rapporteur only

--- a/sarc/notifications/csv_export.py
+++ b/sarc/notifications/csv_export.py
@@ -1,0 +1,65 @@
+import csv
+import io
+from datetime import date
+from urllib.parse import urlencode
+
+from sarc.notifications.usage import RecurringUserRow
+
+
+def _dashboard_link(
+    dashboard_url: str | None, email: str, start: date, end: date
+) -> str:
+    if dashboard_url is None:
+        return ""
+    query = urlencode(
+        {"as_user": email, "start": start.isoformat(), "end": end.isoformat()}
+    )
+    return f"{dashboard_url}?{query}"
+
+
+def build_recurring_distilled_csv(
+    recurring: dict[str, list[RecurringUserRow]],
+    *,
+    active_cycles: int,
+    cycle_dates: list[date],
+    dashboard_url: str | None,
+    window_start: date,
+    window_end: date,
+) -> str:
+    """Build a CSV close copy of the recurring-underusers Slack table: every
+    user per cluster (no cluster_share_threshold truncation — that's already
+    applied upstream by the caller's choice of *recurring*), one column per
+    cycle in *cycle_dates* holding the same marker
+    (``RecurringUserRow.cycle_symbol``) the Slack table renders, with a blank
+    separator column after cycle index ``active_cycles - 1``.
+    """
+    if not recurring:
+        return ""
+
+    n_cycles = len(cycle_dates)
+    buf = io.StringIO()
+    writer = csv.writer(buf)
+
+    header = ["cluster", "User", "user dashboard url", "Unused RGU-h", "Share"]
+    for i, d in enumerate(cycle_dates):
+        if i == active_cycles:
+            header.append("")
+        header.append(d.strftime("%m-%d"))
+    writer.writerow(header)
+
+    for cluster, rows in sorted(recurring.items()):
+        for row in rows:
+            data_row = [
+                cluster,
+                row.email,
+                _dashboard_link(dashboard_url, row.email, window_start, window_end),
+                row.wasted_current_active_window,
+                row.cluster_share,
+            ]
+            for i in range(n_cycles):
+                if i == active_cycles:
+                    data_row.append("")
+                data_row.append(row.cycle_symbol(i))
+            writer.writerow(data_row)
+
+    return buf.getvalue()

--- a/sarc/notifications/messages.py
+++ b/sarc/notifications/messages.py
@@ -179,20 +179,9 @@ def build_recurring_table(
         )
     flag_ws = [len(lbl) for lbl in flag_labels]
 
-    def _flag_cell(
-        flag: bool | None, w: int, has_peak: bool = False, escalated: bool = False
-    ) -> str:
-        if flag is None:
+    def _flag_cell(symbol: str, w: int) -> str:
+        if not symbol:
             return " " * (2 + w)
-        if flag:
-            if escalated:
-                symbol = "!!⚑▲"
-            elif has_peak:
-                symbol = "⚑▲"
-            else:
-                symbol = "▲"
-        else:
-            symbol = "✓"
         return f"  {symbol.rjust(w)}"
 
     def _build_flag_header() -> str:
@@ -204,16 +193,11 @@ def build_recurring_table(
         return "".join(parts)
 
     def _build_flag_cells(row: RecurringUserRow) -> str:
-        cycle_vals = row.cycles
-        esc_flags = row.restrictive_action_flags
         parts = []
         for i, w in enumerate(flag_ws):
             if i == flag_window:
                 parts.append("  |")
-            flag = cycle_vals[i]
-            has_peak = i < len(row.pa_flags) and bool(row.pa_flags[i])
-            escalated = i < len(esc_flags) and bool(esc_flags[i])
-            parts.append(_flag_cell(flag, w, has_peak, escalated))
+            parts.append(_flag_cell(row.cycle_symbol(i), w))
         return "".join(parts)
 
     flag_header = _build_flag_header()

--- a/sarc/notifications/slack.py
+++ b/sarc/notifications/slack.py
@@ -90,6 +90,34 @@ class SlackClient:
             logger.error("Slack channel post failed: %s", exc)
             return SendResult(SendStatus.FAILED, str(exc))
 
+    def upload_files(
+        self,
+        channel: str,
+        files: list[tuple[str, str]],
+        *,
+        initial_comment: str | None = None,
+        thread_ts: str | None = None,
+    ) -> SendResult:
+        """Upload one or more files (filename, content) to a channel.
+
+        Pass thread_ts to upload into a message's thread, same as post_channel.
+        """
+        try:
+            file_uploads = [
+                {"filename": filename, "content": content}
+                for filename, content in files
+            ]
+            self._client.files_upload_v2(
+                channel=channel,
+                file_uploads=file_uploads,
+                initial_comment=initial_comment,
+                thread_ts=thread_ts,
+            )
+            return SendResult(SendStatus.OK)
+        except Exception as exc:
+            logger.error("Slack file upload failed: %s", exc)
+            return SendResult(SendStatus.FAILED, str(exc))
+
     def dm_user(
         self, email: str, text: str, *, preformatted: bool = False
     ) -> SendResult:

--- a/sarc/notifications/usage.py
+++ b/sarc/notifications/usage.py
@@ -1,7 +1,7 @@
 import contextvars
 from collections.abc import Callable, Sequence
 from concurrent.futures import Future, ThreadPoolExecutor
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import date, datetime, timedelta
 from functools import cached_property, partial
 from typing import TypeVar
@@ -161,6 +161,23 @@ class RecurringUserRow:
         length is the ``restrictive_action_run_cycles`` notifications config
         knob."""
         return _restrictive_action_flags(self.pa_flags)
+
+    def cycle_symbol(self, i: int) -> str:
+        """Return the marker for cycle position i, matching the
+        recurring-underusers table rendering: "" for a future cycle
+        (cycles[i] is None, no data yet), "✓" not flagged, "▲" underuser,
+        "⚑▲" personalized-action peak, "!!⚑▲" sustained restrictive-action
+        escalation. Bare symbol, no padding."""
+        flag = self.cycles[i]
+        if flag is None:
+            return ""
+        if not flag:
+            return "✓"
+        if i < len(self.restrictive_action_flags) and self.restrictive_action_flags[i]:
+            return "!!⚑▲"
+        if i < len(self.pa_flags) and self.pa_flags[i]:
+            return "⚑▲"
+        return "▲"
 
 
 def _restrictive_action_flags(flags: list[bool]) -> list[bool]:
@@ -853,7 +870,6 @@ def get_recurring_underusers(
     *,
     min_waste_ratio: float,
     min_waste_rgu_hours: float,
-    cluster_share_threshold: float,
     recurrence_active_cycles: int = 3,
     recurrence_display_cycles: int = 5,
     clusters: list[str] | None = None,
@@ -935,7 +951,7 @@ def get_recurring_underusers(
             clusters=clusters,
         )
 
-    # ── Per-cluster greedy selection (cumulative share >= cluster_share_threshold) ──
+    # ── Per-cluster selection ──
     result: dict[str, list[RecurringUserRow]] = {}
     for cluster, users in sorted(cluster_users.items()):
         cluster_total = sum(u["wasted"] for u in users.values())
@@ -944,16 +960,8 @@ def get_recurring_underusers(
             users.items(), key=lambda kv: kv[1]["wasted"], reverse=True
         )
 
-        selected: list[tuple[int, dict]] = []
-        cumulative = 0.0
-        for uid, u in sorted_users:
-            selected.append((uid, u))
-            cumulative += u["wasted"]
-            if cumulative / cluster_total >= cluster_share_threshold:
-                break
-
         rows_out = []
-        for uid, u in selected:
+        for uid, u in sorted_users:
             cycles_for_user = [
                 (None if cf is None else uid in cf) for cf in cycle_flagged
             ]
@@ -978,5 +986,51 @@ def get_recurring_underusers(
                 )
             )
         result[cluster] = rows_out
+
+    return result
+
+
+def select_recurring_table_view(
+    all_users: dict[str, list[RecurringUserRow]],
+    *,
+    display_cycles: int,
+    cluster_share_threshold: float,
+) -> dict[str, list[RecurringUserRow]]:
+    """Derive a threshold-selected, narrower-cycle-window table view from a full
+    (all-users, wide-cycle) ``get_recurring_underusers()`` pull.
+
+    Exact, not an approximation: per-user ``wasted_current_active_window``/
+    ``cluster_share`` and each cycle position's flags are already independent of
+    ``recurrence_display_cycles``/``cluster_share_threshold`` in the underlying
+    aggregate — this only re-applies the same greedy cumulative- share selection
+    used by ``get_recurring_underusers`` and truncates the per-cycle lists,
+    giving identical results to a direct call with
+    ``recurrence_display_cycles=display_cycles,
+    cluster_share_threshold=cluster_share_threshold``.
+
+    *all_users* rows must already be sorted descending by
+    ``wasted_current_active_window`` within each cluster (as returned by
+    ``get_recurring_underusers``).
+    """
+    result: dict[str, list[RecurringUserRow]] = {}
+    for cluster, rows in all_users.items():
+        cluster_total = sum(r.wasted_current_active_window for r in rows)
+
+        selected = []
+        cumulative = 0.0
+        for r in rows:
+            selected.append(r)
+            cumulative += r.wasted_current_active_window
+            if cumulative / cluster_total >= cluster_share_threshold:
+                break
+
+        result[cluster] = [
+            replace(
+                r,
+                cycles=r.cycles[:display_cycles],
+                pa_flags=r.pa_flags[:display_cycles],
+            )
+            for r in selected
+        ]
 
     return result

--- a/tests/unittests/notifications/test_cli.py
+++ b/tests/unittests/notifications/test_cli.py
@@ -292,6 +292,7 @@ def _mock_slack(dm_status=SendStatus.OK, channel_status=SendStatus.OK):
     inst.dm_user.return_value = SendResult(dm_status)
     ts = "111.222" if channel_status == SendStatus.OK else None
     inst.post_channel.return_value = SendResult(channel_status, ts=ts)
+    inst.upload_files.return_value = SendResult(SendStatus.OK)
     cls = MagicMock(return_value=inst)
     return cls, inst
 
@@ -1074,3 +1075,65 @@ def test_n3_usage_report_positive_case(usage_report_db, cli_main, capsys):
     out = captured.out
     assert "=== Usage Report Previews" in out
     assert "beaubonhomme@mila.quebec" in out
+
+
+# ── Recurring-underusers CSV export ───────────────────────────────────────────
+
+_DASHBOARD_URL = "https://sarc-api.example.com/dash/metrics"
+
+
+def test_send_uploads_recurring_csvs_when_dashboard_url_set(
+    notify_db, cli_main, monkeypatch
+):
+    slack_cls, slack_inst = _mock_slack()
+    _patch_senders(monkeypatch, slack_cls)
+    cfg = {
+        **_NOTIFY_CFG,
+        "send_underusage_report": True,
+        "send_usage_report": False,
+        "dashboard_url": _DASHBOARD_URL,
+    }
+    with gifnoc.overlay({"sarc.notifications": cfg}):
+        rc = cli_main(
+            ["notify", "usage", "--as-of", _CYCLE_WEEK, "--send", "--ignore-store"]
+        )
+    assert rc == 0
+    digests, _replies = _channel_posts(slack_inst)
+    assert slack_inst.upload_files.call_count == 1
+    call = slack_inst.upload_files.call_args
+    assert call.args[0] == "#test-channel"
+    files = call.args[1]
+    assert len(files) == 1
+    names = [f[0] for f in files]
+    assert any("distilled" in n for n in names)
+    for _name, content in files:
+        assert content  # non-empty CSV body
+    assert len(digests) == 1
+    # thread_ts must match the digest post's ts (via post_channel's return value).
+    assert call.kwargs["thread_ts"] == slack_inst.post_channel.return_value.ts
+
+
+def test_send_upload_failure_logs_error(notify_db, cli_main, monkeypatch, caplog):
+    slack_cls, slack_inst = _mock_slack()
+    slack_inst.upload_files.return_value = SendResult(SendStatus.FAILED, "upload_boom")
+    _patch_senders(monkeypatch, slack_cls)
+    cfg = {**_NOTIFY_CFG, "send_underusage_report": True, "send_usage_report": False}
+    with gifnoc.overlay({"sarc.notifications": cfg}):
+        rc = cli_main(["notify", "usage", "--as-of", _CYCLE_WEEK, "--send"])
+    assert rc == 0
+    assert any(
+        "Failed to upload recurring-underusers CSVs" in r.message
+        for r in caplog.records
+    )
+    assert any("upload_boom" in r.message for r in caplog.records)
+
+
+def test_dry_run_does_not_upload_csvs(notify_db, cli_main, monkeypatch):
+    slack_cls = MagicMock()
+    _patch_senders(monkeypatch, slack_cls)
+    cfg = {**_NOTIFY_CFG, "dashboard_url": _DASHBOARD_URL}
+    with gifnoc.overlay({"sarc.notifications": cfg}):
+        rc = cli_main(["notify", "usage", "--as-of", _CYCLE_WEEK])
+    assert rc == 0
+    # SlackClient is never instantiated in dry-run mode.
+    slack_cls.assert_not_called()

--- a/tests/unittests/notifications/test_csv_export.py
+++ b/tests/unittests/notifications/test_csv_export.py
@@ -1,0 +1,217 @@
+"""Tests for the recurring-underusers CSV exports."""
+
+import csv
+import io
+from datetime import date
+
+import gifnoc
+
+from sarc.notifications.csv_export import _dashboard_link, build_recurring_distilled_csv
+from sarc.notifications.usage import RecurringUserRow
+from tests.unittests.notifications._factory import (
+    UNDERUSAGE_REPORT_TEMPLATE,
+    USAGE_REPORT_TEMPLATE,
+)
+
+_DASHBOARD_URL = "https://sarc-api.example.com/dash/metrics"
+_NOTIFY_CFG = {
+    "slack_underusage": {
+        "description": "test channel",
+        "token": "xoxb-test-token",
+        "channel": "#test-channel",
+    },
+    "slack_usage": {
+        "description": "test channel",
+        "token": "xoxb-test-token",
+        "channel": "#test-channel",
+    },
+    "underusage_report_template": UNDERUSAGE_REPORT_TEMPLATE,
+    "usage_report_template": USAGE_REPORT_TEMPLATE,
+    "dashboard_url": _DASHBOARD_URL,
+}
+
+_CYCLE_DATES = [
+    date(2024, 6, 24),
+    date(2024, 6, 10),
+    date(2024, 5, 27),
+    date(2024, 5, 13),
+    date(2024, 4, 29),
+]
+
+_WINDOW_START = date(2024, 5, 27)
+_WINDOW_END = date(2024, 6, 24)
+
+_ROW_ALICE = RecurringUserRow(
+    email="alice@mila.quebec",
+    display_name="Alice Liddell",
+    cluster="narval",
+    wasted_current_active_window=4200.0,
+    cluster_share=0.18,
+    cycles=[True, True, True, True, True],
+    flagged_for_personalized_action=True,
+    pa_flags=[True, True, True, True, False],
+)
+
+_ROW_BOB = RecurringUserRow(
+    email="bob@mila.quebec",
+    display_name="Bob Marley",
+    cluster="narval",
+    wasted_current_active_window=2600.0,
+    cluster_share=0.11,
+    cycles=[True, False, True, True, True],
+    flagged_for_personalized_action=False,
+)
+
+_ROW_FUTURE = RecurringUserRow(
+    email="carol@mila.quebec",
+    display_name="Carol Danvers",
+    cluster="narval",
+    wasted_current_active_window=1100.0,
+    cluster_share=0.05,
+    cycles=[None, True, True, False, False],
+    flagged_for_personalized_action=False,
+)
+
+
+def _rows(text: str) -> list[list[str]]:
+    return list(csv.reader(io.StringIO(text)))
+
+
+# ── _dashboard_link ────────────────────────────────────────────────────────────
+
+
+def test_dashboard_link_none_url_returns_empty():
+    assert _dashboard_link(None, "alice@mila.quebec", _WINDOW_START, _WINDOW_END) == ""
+
+
+def test_dashboard_link_urlencodes_email():
+    link = _dashboard_link(
+        _DASHBOARD_URL, "alice+test@mila.quebec", _WINDOW_START, _WINDOW_END
+    )
+    assert "alice%2Btest%40mila.quebec" in link
+    assert "+test@mila.quebec" not in link
+
+
+def test_dashboard_link_has_start_end_dates():
+    link = _dashboard_link(
+        _DASHBOARD_URL, "alice@mila.quebec", _WINDOW_START, _WINDOW_END
+    )
+    assert "start=2024-05-27" in link
+    assert "end=2024-06-24" in link
+    assert link.startswith(_DASHBOARD_URL + "?")
+
+
+# ── build_recurring_distilled_csv ──────────────────────────────────────────────
+
+
+def test_distilled_empty_recurring_returns_empty_string():
+    assert (
+        build_recurring_distilled_csv(
+            {},
+            active_cycles=3,
+            cycle_dates=_CYCLE_DATES,
+            dashboard_url=_DASHBOARD_URL,
+            window_start=_WINDOW_START,
+            window_end=_WINDOW_END,
+        )
+        == ""
+    )
+
+
+def test_distilled_header_shape_and_separator_position():
+    with gifnoc.overlay({"sarc.notifications": _NOTIFY_CFG}):
+        text = build_recurring_distilled_csv(
+            {"narval": [_ROW_ALICE]},
+            active_cycles=3,
+            cycle_dates=_CYCLE_DATES,
+            dashboard_url=_DASHBOARD_URL,
+            window_start=_WINDOW_START,
+            window_end=_WINDOW_END,
+        )
+    header = _rows(text)[0]
+    assert header[:5] == [
+        "cluster",
+        "User",
+        "user dashboard url",
+        "Unused RGU-h",
+        "Share",
+    ]
+    # 3 active-cycle date columns, then a blank separator, then the remaining 2.
+    assert header[5:8] == ["06-24", "06-10", "05-27"]
+    assert header[8] == ""
+    assert header[9:11] == ["05-13", "04-29"]
+
+
+def test_distilled_row_has_raw_numbers_and_markers():
+    with gifnoc.overlay({"sarc.notifications": _NOTIFY_CFG}):
+        text = build_recurring_distilled_csv(
+            {"narval": [_ROW_ALICE]},
+            active_cycles=3,
+            cycle_dates=_CYCLE_DATES,
+            dashboard_url=_DASHBOARD_URL,
+            window_start=_WINDOW_START,
+            window_end=_WINDOW_END,
+        )
+    row = _rows(text)[1]
+    assert row[0] == "narval"
+    assert row[1] == "alice@mila.quebec"
+    assert row[2].startswith(_DASHBOARD_URL + "?")
+    assert row[3] == "4200.0"  # raw float, not "4 200"
+    assert row[4] == "0.18"  # raw fraction, not "18 %"
+    # cycles=[T,T,T,T,T], pa_flags=[T,T,T,T,F] -> 4-run at 0..3 (default run=4)
+    # escalates the newest cell; position 4 has no pa_flags peak.
+    assert row[5] == "!!⚑▲"
+    assert row[6] == "⚑▲"
+    assert row[7] == "⚑▲"
+    assert row[8] == ""  # separator
+    assert row[9] == "⚑▲"
+    assert row[10] == "▲"
+
+
+def test_distilled_future_cycle_and_not_flagged_markers():
+    with gifnoc.overlay({"sarc.notifications": _NOTIFY_CFG}):
+        text = build_recurring_distilled_csv(
+            {"narval": [_ROW_FUTURE]},
+            active_cycles=3,
+            cycle_dates=_CYCLE_DATES,
+            dashboard_url=_DASHBOARD_URL,
+            window_start=_WINDOW_START,
+            window_end=_WINDOW_END,
+        )
+    row = _rows(text)[1]
+    # cycles=[None, True, True, False, False]
+    assert row[5] == ""  # future cycle blank
+    assert row[6] == "▲"
+    assert row[7] == "▲"
+    assert row[8] == ""  # separator
+    assert row[9] == "✓"
+    assert row[10] == "✓"
+
+
+def test_distilled_multi_cluster_sorted_alphabetically():
+    with gifnoc.overlay({"sarc.notifications": _NOTIFY_CFG}):
+        text = build_recurring_distilled_csv(
+            {"zeta": [_ROW_BOB], "alpha": [_ROW_ALICE]},
+            active_cycles=3,
+            cycle_dates=_CYCLE_DATES,
+            dashboard_url=_DASHBOARD_URL,
+            window_start=_WINDOW_START,
+            window_end=_WINDOW_END,
+        )
+    rows = _rows(text)
+    assert rows[1][0] == "alpha"
+    assert rows[2][0] == "zeta"
+
+
+def test_distilled_dashboard_url_none_leaves_link_blank():
+    with gifnoc.overlay({"sarc.notifications": _NOTIFY_CFG}):
+        text = build_recurring_distilled_csv(
+            {"narval": [_ROW_ALICE]},
+            active_cycles=3,
+            cycle_dates=_CYCLE_DATES,
+            dashboard_url=None,
+            window_start=_WINDOW_START,
+            window_end=_WINDOW_END,
+        )
+    row = _rows(text)[1]
+    assert row[2] == ""

--- a/tests/unittests/notifications/test_recurring.py
+++ b/tests/unittests/notifications/test_recurring.py
@@ -14,6 +14,7 @@ from sarc.notifications.usage import (
     _week_anchor,
     get_cycle_dates,
     get_recurring_underusers,
+    select_recurring_table_view,
     usage_cycle_length_weeks,
 )
 from tests.unittests.notifications._factory import (
@@ -30,7 +31,6 @@ _14D = timedelta(days=14)
 # Default keyword args for build_recurring_table and get_recurring_underusers callers
 # that don't need to exercise specific window/share values.
 _BRT_KW = {"cluster_share_threshold": 0.30, "active_cycles": 3}
-_GRU_KW = {"cluster_share_threshold": 0.30}
 
 # Cycle windows (rolling from _TEST_END)
 # W0:  [2024-06-16, 2024-06-30]
@@ -174,13 +174,18 @@ def recurring_db(read_write_db):
 
 
 def test_selection_threshold(recurring_db):
-    with gifnoc.overlay({"sarc.notifications": _NOTIFY_CFG}):
-        result = get_recurring_underusers(
+    with gifnoc.overlay({"sarc.notifications": _NOTIFY_CFG}) as config:
+        ncfg = config.sarc.notifications
+        unfiltered_result = get_recurring_underusers(
             _TEST_END,
             min_waste_ratio=_MIN_WASTE_RATIO,
             min_waste_rgu_hours=_MIN_WASTE_RGU_HOURS,
-            cluster_share_threshold=0.70,
             ignore_store=True,
+        )
+        result = select_recurring_table_view(
+            unfiltered_result,
+            display_cycles=ncfg.recurrence_display_cycles,
+            cluster_share_threshold=0.70,
         )
     mila_rows = result.get("mila", [])
     selected_emails = {r.email for r in mila_rows}
@@ -203,13 +208,17 @@ def test_all_users_included_when_threshold_is_one(recurring_db):
     # config, which is only defined inside this overlay.
     with gifnoc.overlay({"sarc.notifications": _NOTIFY_CFG}) as config:
         ncfg = config.sarc.notifications
-        result = get_recurring_underusers(
+        unfiltered_result = get_recurring_underusers(
             _TEST_END,
             min_waste_ratio=_MIN_WASTE_RATIO,
             min_waste_rgu_hours=_MIN_WASTE_RGU_HOURS,
-            cluster_share_threshold=1.0,
             personalized_action_min_waste_rgu_hours=ncfg.personalized_action_min_waste_rgu_hours,
             ignore_store=True,
+        )
+        result = select_recurring_table_view(
+            unfiltered_result,
+            display_cycles=ncfg.recurrence_display_cycles,
+            cluster_share_threshold=1.0,
         )
         # Trigger cache on restrictive_action_flags
         for rows in result.values():
@@ -271,13 +280,15 @@ def test_all_users_included_when_threshold_is_one(recurring_db):
 
 def test_display_cycles_columns(recurring_db):
     with gifnoc.overlay({"sarc.notifications": _NOTIFY_CFG}):
-        result = get_recurring_underusers(
+        unfiltered_result = get_recurring_underusers(
             _TEST_END,
             min_waste_ratio=_MIN_WASTE_RATIO,
             min_waste_rgu_hours=_MIN_WASTE_RGU_HOURS,
-            cluster_share_threshold=1.0,
             recurrence_display_cycles=4,
             ignore_store=True,
+        )
+        result = select_recurring_table_view(
+            unfiltered_result, display_cycles=4, cluster_share_threshold=1.0
         )
     # Test cycles 4 produces 4 columns
     for rows in result.values():
@@ -285,13 +296,15 @@ def test_display_cycles_columns(recurring_db):
             assert len(row.cycles) == 4
 
     with gifnoc.overlay({"sarc.notifications": _NOTIFY_CFG}):
-        result = get_recurring_underusers(
+        unfiltered_result = get_recurring_underusers(
             _TEST_END,
             min_waste_ratio=_MIN_WASTE_RATIO,
             min_waste_rgu_hours=_MIN_WASTE_RGU_HOURS,
-            cluster_share_threshold=1.0,
             recurrence_display_cycles=6,
             ignore_store=True,
+        )
+        result = select_recurring_table_view(
+            unfiltered_result, display_cycles=6, cluster_share_threshold=1.0
         )
     # Test cycles 6 produces 6 columns
     for rows in result.values():
@@ -315,15 +328,20 @@ def test_active_cycles_personalized_action(recurring_db):
             True,
         ),  # PA window=10w: firstuser waste=456 >= 300 floor (W-8 enters window)
     ]:
-        with gifnoc.overlay({"sarc.notifications": _NOTIFY_CFG}):
-            result = get_recurring_underusers(
+        with gifnoc.overlay({"sarc.notifications": _NOTIFY_CFG}) as config:
+            ncfg = config.sarc.notifications
+            unfiltered_result = get_recurring_underusers(
                 _TEST_END,
                 min_waste_ratio=_MIN_WASTE_RATIO,
                 min_waste_rgu_hours=_MIN_WASTE_RGU_HOURS,
-                cluster_share_threshold=1.0,
                 recurrence_active_cycles=active_cycles,
                 personalized_action_min_waste_rgu_hours=300.0,
                 ignore_store=True,
+            )
+            result = select_recurring_table_view(
+                unfiltered_result,
+                display_cycles=ncfg.recurrence_display_cycles,
+                cluster_share_threshold=1.0,
             )
             row = next(r for r in result["mila"] if r.email == "firstuser@mila.quebec")
             assert row.flagged_for_personalized_action is expected, (
@@ -336,14 +354,20 @@ def test_active_cycles_personalized_action(recurring_db):
 
 def test_empty_db_returns_empty_dict(read_write_db):
     before = datetime(2020, 1, 1, tzinfo=UTC)
-    with gifnoc.overlay({"sarc.notifications": _NOTIFY_CFG}):
-        result = get_recurring_underusers(
+    with gifnoc.overlay({"sarc.notifications": _NOTIFY_CFG}) as config:
+        ncfg = config.sarc.notifications
+        unfiltered_result = get_recurring_underusers(
             before,
             min_waste_ratio=_MIN_WASTE_RATIO,
             min_waste_rgu_hours=_MIN_WASTE_RGU_HOURS,
-            **_GRU_KW,
             ignore_store=True,
         )
+        result = select_recurring_table_view(
+            unfiltered_result,
+            display_cycles=ncfg.recurrence_display_cycles,
+            cluster_share_threshold=0.30,
+        )
+
     assert result == {}
 
 
@@ -708,13 +732,18 @@ def test_anchor_year_boundary_pinned(cycle_weeks, end, expected_anchor):
 def test_off_cycle_week_end_w0_is_none(recurring_db):
     # _OFF_CYCLE_MON = 2024-06-17 (wk 25, off-cycle) → anchor = 2024-06-24 > end
     # → w0=None
-    with gifnoc.overlay({"sarc.notifications": _NOTIFY_CFG}):
-        result = get_recurring_underusers(
+    with gifnoc.overlay({"sarc.notifications": _NOTIFY_CFG}) as config:
+        ncfg = config.sarc.notifications
+        unfiltered_result = get_recurring_underusers(
             _OFF_CYCLE_MON,
             min_waste_ratio=_MIN_WASTE_RATIO,
             min_waste_rgu_hours=_MIN_WASTE_RGU_HOURS,
-            cluster_share_threshold=0.70,
             ignore_store=True,
+        )
+        result = select_recurring_table_view(
+            unfiltered_result,
+            display_cycles=ncfg.recurrence_display_cycles,
+            cluster_share_threshold=0.70,
         )
     assert result, "expected selected users for the off-cycle-week window"
     for rows in result.values():
@@ -728,14 +757,19 @@ def test_off_cycle_week_end_personalized_action_floor_controls(recurring_db):
     # With w0=None (off-cycle-week end) position-0 PA is suppressed regardless of waste,
     # because cycle_flagged[0] is None. Here a high floor independently keeps everyone
     # below the threshold, so all rows are unflagged.
-    with gifnoc.overlay({"sarc.notifications": _NOTIFY_CFG}):
-        result = get_recurring_underusers(
+    with gifnoc.overlay({"sarc.notifications": _NOTIFY_CFG}) as config:
+        ncfg = config.sarc.notifications
+        unfiltered_result = get_recurring_underusers(
             _OFF_CYCLE_MON,
             min_waste_ratio=_MIN_WASTE_RATIO,
             min_waste_rgu_hours=_MIN_WASTE_RGU_HOURS,
-            cluster_share_threshold=0.70,
             personalized_action_min_waste_rgu_hours=999999.0,
             ignore_store=True,
+        )
+        result = select_recurring_table_view(
+            unfiltered_result,
+            display_cycles=ncfg.recurrence_display_cycles,
+            cluster_share_threshold=0.70,
         )
     for rows in result.values():
         for row in rows:
@@ -1014,14 +1048,19 @@ def test_table_no_escalation_without_four_run():
 def test_wasted_6w_uses_scaled_waste(recurring_db):
     # firstuser: util=0.05, threshold=0.05 → credited_used=LEAST(rgu_h, rgu_h*1.0)=rgu_h
     # → wasted=0 → excluded from the recurring table entirely
-    with gifnoc.overlay({"sarc.notifications": _NOTIFY_CFG}):
-        result = get_recurring_underusers(
+    with gifnoc.overlay({"sarc.notifications": _NOTIFY_CFG}) as config:
+        ncfg = config.sarc.notifications
+        unfiltered_result = get_recurring_underusers(
             _TEST_END,
             min_waste_ratio=_MIN_WASTE_RATIO,
             min_waste_rgu_hours=_MIN_WASTE_RGU_HOURS,
-            cluster_share_threshold=1.0,
             utilization_ceiling=0.05,
             ignore_store=True,
+        )
+        result = select_recurring_table_view(
+            unfiltered_result,
+            display_cycles=ncfg.recurrence_display_cycles,
+            cluster_share_threshold=1.0,
         )
     emails = {r.email for rows in result.values() for r in rows}
     assert "firstuser@mila.quebec" not in emails
@@ -1029,13 +1068,18 @@ def test_wasted_6w_uses_scaled_waste(recurring_db):
 
 def test_true_wasted_field_populated(recurring_db):
     # At identity threshold, RecurringUserRow.true_wasted should be positive.
-    with gifnoc.overlay({"sarc.notifications": _NOTIFY_CFG}):
-        result = get_recurring_underusers(
+    with gifnoc.overlay({"sarc.notifications": _NOTIFY_CFG}) as config:
+        ncfg = config.sarc.notifications
+        unfiltered_result = get_recurring_underusers(
             _TEST_END,
             min_waste_ratio=_MIN_WASTE_RATIO,
             min_waste_rgu_hours=_MIN_WASTE_RGU_HOURS,
-            cluster_share_threshold=1.0,
             ignore_store=True,
+        )
+        result = select_recurring_table_view(
+            unfiltered_result,
+            display_cycles=ncfg.recurrence_display_cycles,
+            cluster_share_threshold=1.0,
         )
     row = next(r for r in result["mila"] if r.email == "firstuser@mila.quebec")
     assert row.true_wasted > 0.0
@@ -1047,14 +1091,19 @@ def test_personalized_action_floor(recurring_db):
     # the most-recent cycle (cycle_flagged[0]). fourthuser clears the floor over the
     # active window but is NOT a current-cycle underuser (cycles == [False]*3 +
     # [True]*2), so PA is suppressed for them while the other three are flagged.
-    with gifnoc.overlay({"sarc.notifications": _NOTIFY_CFG}):
-        result = get_recurring_underusers(
+    with gifnoc.overlay({"sarc.notifications": _NOTIFY_CFG}) as config:
+        ncfg = config.sarc.notifications
+        unfiltered_result = get_recurring_underusers(
             _TEST_END,
             min_waste_ratio=_MIN_WASTE_RATIO,
             min_waste_rgu_hours=_MIN_WASTE_RGU_HOURS,
-            cluster_share_threshold=1.0,
             personalized_action_min_waste_rgu_hours=0.0,
             ignore_store=True,
+        )
+        result = select_recurring_table_view(
+            unfiltered_result,
+            display_cycles=ncfg.recurrence_display_cycles,
+            cluster_share_threshold=1.0,
         )
     flagged = {
         r.email: r.flagged_for_personalized_action
@@ -1069,14 +1118,19 @@ def test_personalized_action_floor(recurring_db):
     assert flagged["fourthuser@mila.quebec"] is False
 
     # With a very high floor, no user crosses the threshold → all False.
-    with gifnoc.overlay({"sarc.notifications": _NOTIFY_CFG}):
-        result = get_recurring_underusers(
+    with gifnoc.overlay({"sarc.notifications": _NOTIFY_CFG}) as config:
+        ncfg = config.sarc.notifications
+        unfiltered_result = get_recurring_underusers(
             _TEST_END,
             min_waste_ratio=_MIN_WASTE_RATIO,
             min_waste_rgu_hours=_MIN_WASTE_RGU_HOURS,
-            cluster_share_threshold=1.0,
             personalized_action_min_waste_rgu_hours=999999.0,
             ignore_store=True,
+        )
+        result = select_recurring_table_view(
+            unfiltered_result,
+            display_cycles=ncfg.recurrence_display_cycles,
+            cluster_share_threshold=1.0,
         )
     for rows in result.values():
         for row in rows:
@@ -1148,16 +1202,18 @@ def test_pa_flags_four_scenarios(pa_scenario_db):
     """pa_flags are computed correctly for the four canonical scenarios."""
     users = pa_scenario_db
     with gifnoc.overlay({"sarc.notifications": _NOTIFY_CFG}):
-        result = get_recurring_underusers(
+        unfiltered_result = get_recurring_underusers(
             _TEST_END,
             min_waste_ratio=0.0,
             min_waste_rgu_hours=0.0,
-            cluster_share_threshold=1.1,
             recurrence_active_cycles=3,
             recurrence_display_cycles=5,
             clusters=["mila"],
             personalized_action_min_waste_rgu_hours=30.0,
             ignore_store=True,
+        )
+        result = select_recurring_table_view(
+            unfiltered_result, display_cycles=5, cluster_share_threshold=1.1
         )
     rows = {r.email: r for r in result.get("mila", [])}
 
@@ -1182,3 +1238,179 @@ def test_pa_flags_four_scenarios(pa_scenario_db):
     with gifnoc.overlay({"sarc.notifications": _NOTIFY_CFG}):
         for u in (u1, u2, u3, u4):
             assert u.restrictive_action_flags == [False] * 5
+
+
+# ── RecurringUserRow.cycle_symbol ─────────────────────────────────────────────
+
+
+def test_cycle_symbol_future_cycle_is_blank():
+    row = RecurringUserRow(
+        email="x@mila.quebec",
+        display_name="X",
+        cluster="mila",
+        wasted_current_active_window=1.0,
+        cluster_share=0.1,
+        cycles=[None],
+        flagged_for_personalized_action=False,
+    )
+    with gifnoc.overlay({"sarc.notifications": _NOTIFY_CFG}):
+        assert row.cycle_symbol(0) == ""
+
+
+def test_cycle_symbol_not_underuser_is_check():
+    row = RecurringUserRow(
+        email="x@mila.quebec",
+        display_name="X",
+        cluster="mila",
+        wasted_current_active_window=1.0,
+        cluster_share=0.1,
+        cycles=[False],
+        flagged_for_personalized_action=False,
+    )
+    with gifnoc.overlay({"sarc.notifications": _NOTIFY_CFG}):
+        assert row.cycle_symbol(0) == "✓"
+
+
+def test_cycle_symbol_underuser_no_peak_is_triangle():
+    row = RecurringUserRow(
+        email="x@mila.quebec",
+        display_name="X",
+        cluster="mila",
+        wasted_current_active_window=1.0,
+        cluster_share=0.1,
+        cycles=[True],
+        flagged_for_personalized_action=False,
+        pa_flags=[False],
+    )
+    with gifnoc.overlay({"sarc.notifications": _NOTIFY_CFG}):
+        assert row.cycle_symbol(0) == "▲"
+
+
+def test_cycle_symbol_pa_peak_is_flag_triangle():
+    row = RecurringUserRow(
+        email="x@mila.quebec",
+        display_name="X",
+        cluster="mila",
+        wasted_current_active_window=1.0,
+        cluster_share=0.1,
+        cycles=[True],
+        flagged_for_personalized_action=True,
+        pa_flags=[True],
+    )
+    with gifnoc.overlay({"sarc.notifications": _NOTIFY_CFG}):
+        assert row.cycle_symbol(0) == "⚑▲"
+
+
+def test_cycle_symbol_escalated_is_double_bang():
+    row = RecurringUserRow(
+        email="x@mila.quebec",
+        display_name="X",
+        cluster="mila",
+        wasted_current_active_window=1.0,
+        cluster_share=0.1,
+        cycles=[True, True, True, True],
+        flagged_for_personalized_action=True,
+        pa_flags=[True, True, True, True],
+    )
+    with gifnoc.overlay({"sarc.notifications": _NOTIFY_CFG}):
+        assert row.cycle_symbol(0) == "!!⚑▲"
+
+
+def test_cycle_symbol_matches_expected_sequence():
+    # _ROW_PEAK_AT_W4: cycles=[F,F,T,T,T], pa_flags=[F,F,T,F,F] (no 4-run).
+    with gifnoc.overlay({"sarc.notifications": _NOTIFY_CFG}):
+        symbols = [_ROW_PEAK_AT_W4.cycle_symbol(i) for i in range(5)]
+    assert symbols == ["✓", "✓", "⚑▲", "▲", "▲"]
+
+
+# ── Floating-point-safe "select all" threshold ────────────────────────────────
+
+
+def test_selection_threshold_above_one_includes_all(recurring_db):
+    # Confirms the fix is a >= comparison, not an exact-equality special case
+    # for 1.0 only.
+    with gifnoc.overlay({"sarc.notifications": _NOTIFY_CFG}) as config:
+        ncfg = config.sarc.notifications
+        unfiltered_result = get_recurring_underusers(
+            _TEST_END,
+            min_waste_ratio=_MIN_WASTE_RATIO,
+            min_waste_rgu_hours=_MIN_WASTE_RGU_HOURS,
+            ignore_store=True,
+        )
+        result = select_recurring_table_view(
+            unfiltered_result,
+            display_cycles=ncfg.recurrence_display_cycles,
+            cluster_share_threshold=1.5,
+        )
+    mila_emails = {r.email for r in result.get("mila", [])}
+    assert mila_emails == {
+        "firstuser@mila.quebec",
+        "seconduser@mila.quebec",
+        "thirduser@mila.quebec",
+        "fourthuser@mila.quebec",
+    }
+
+
+# ── select_recurring_table_view ───────────────────────────────────────────────
+
+
+def test_select_recurring_table_view_narrows_cycles_and_pa_flags():
+    row = RecurringUserRow(
+        email="alice@mila.quebec",
+        display_name="Alice",
+        cluster="narval",
+        wasted_current_active_window=100.0,
+        cluster_share=1.0,
+        cycles=[True, True, True, True, True],
+        flagged_for_personalized_action=True,
+        pa_flags=[True, True, True, True, False],
+    )
+    with gifnoc.overlay({"sarc.notifications": _NOTIFY_CFG}):
+        result = select_recurring_table_view(
+            {"narval": [row]}, display_cycles=3, cluster_share_threshold=1.0
+        )
+        narrowed = result["narval"][0]
+        assert narrowed.cycles == [True, True, True]
+        assert narrowed.pa_flags == [True, True, True]
+        # restrictive_action_flags must be recomputed against the sliced (len-3)
+        # pa_flags, not stay stale at the original 5-length value — a 3-cycle
+        # window can't contain a 4-cycle run, so no escalation.
+        assert narrowed.restrictive_action_flags == [False, False, False]
+
+
+def test_select_recurring_table_view_reapplies_threshold_selection():
+    rows = [
+        RecurringUserRow(
+            email="a@mila.quebec",
+            display_name="A",
+            cluster="narval",
+            wasted_current_active_window=60.0,
+            cluster_share=0.6,
+            cycles=[True] * 5,
+            flagged_for_personalized_action=False,
+        ),
+        RecurringUserRow(
+            email="b@mila.quebec",
+            display_name="B",
+            cluster="narval",
+            wasted_current_active_window=30.0,
+            cluster_share=0.3,
+            cycles=[True] * 5,
+            flagged_for_personalized_action=False,
+        ),
+        RecurringUserRow(
+            email="c@mila.quebec",
+            display_name="C",
+            cluster="narval",
+            wasted_current_active_window=10.0,
+            cluster_share=0.1,
+            cycles=[True] * 5,
+            flagged_for_personalized_action=False,
+        ),
+    ]
+    with gifnoc.overlay({"sarc.notifications": _NOTIFY_CFG}):
+        result = select_recurring_table_view(
+            {"narval": rows}, display_cycles=5, cluster_share_threshold=0.70
+        )
+    # a (0.6) + b (0.3) = 0.9 >= 0.70 -> stop after b; c excluded.
+    assert [r.email for r in result["narval"]] == ["a@mila.quebec", "b@mila.quebec"]

--- a/tests/unittests/notifications/test_slack.py
+++ b/tests/unittests/notifications/test_slack.py
@@ -95,6 +95,43 @@ def test_post_channel_api_error():
     assert result.ts is None
 
 
+# ── upload_files ──────────────────────────────────────────────────────────────
+
+
+def test_upload_files_success():
+    web = MagicMock()
+    client = _make_client(web)
+    result = client.upload_files(
+        "#alerts", [("a.csv", "a,b\n1,2"), ("b.csv", "x,y\n3,4")]
+    )
+    web.files_upload_v2.assert_called_once_with(
+        channel="#alerts",
+        file_uploads=[
+            {"filename": "a.csv", "content": "a,b\n1,2"},
+            {"filename": "b.csv", "content": "x,y\n3,4"},
+        ],
+        initial_comment=None,
+        thread_ts=None,
+    )
+    assert result.status == SendStatus.OK
+
+
+def test_upload_files_thread_ts_passed_through():
+    web = MagicMock()
+    client = _make_client(web)
+    client.upload_files("#alerts", [("a.csv", "a,b")], thread_ts="111.222")
+    assert web.files_upload_v2.call_args.kwargs["thread_ts"] == "111.222"
+
+
+def test_upload_files_api_error():
+    web = MagicMock()
+    web.files_upload_v2.side_effect = Exception("missing_scope")
+    client = _make_client(web)
+    result = client.upload_files("#alerts", [("a.csv", "a,b")])
+    assert result.status == SendStatus.FAILED
+    assert "missing_scope" in result.detail
+
+
 # ── dm_user ───────────────────────────────────────────────────────────────────
 
 

--- a/tests/unittests/notifications/test_usage_refresh_store.py
+++ b/tests/unittests/notifications/test_usage_refresh_store.py
@@ -269,7 +269,6 @@ def test_off_cycle_week_end_store_path_w0_excluded_but_aggregated(
             off_cycle_end,
             min_waste_ratio=_MIN_WASTE_RATIO,
             min_waste_rgu_hours=_MIN_WASTE_RGU_HOURS,
-            cluster_share_threshold=0.30,
             ignore_store=False,
         )  # clusters omitted -> None -> exercises the `if clusters:` false arm
 


### PR DESCRIPTION
## Summary
Attaches a wider, unfiltered CSV export of the recurring-underusers data as a threaded reply to the admin digest Slack post, so admins see the full picture (all users, `history_cycles` cycles) instead of just the Slack table's truncation (top users up to the cluster-share threshold, `recurrence_display_cycles` cycles).

## Changes
- New `sarc/notifications/csv_export.py`: `build_recurring_distilled_csv` builds a CSV close-copy of the recurring table (cluster, user, dashboard link, unused RGU-h, share, per-cycle markers) with a blank separator column between active and historical cycles.
- `SlackClient.upload_files` (`sarc/notifications/slack.py`): uploads one or more files to a channel/thread via `files_upload_v2`.
- `sarc/cli/notify/usage.py`: the admin-digest path now pulls the full, unfiltered recurring-underusers data (`history_cycles` cycles, no cluster-share cutoff), derives the narrower Slack table view from it via the new `select_recurring_table_view`, and uploads the CSV as a threaded reply after the digest post.
- `sarc/notifications/usage.py`: `get_recurring_underusers` no longer applies `cluster_share_threshold` selection itself — that moved into the new `select_recurring_table_view` helper, letting the CLI derive both the full CSV data and the trimmed Slack view from one query, using the existing `history_cycles` config to size the wide pull instead of `recurrence_display_cycles`. Added `RecurringUserRow.cycle_symbol` to centralize the marker logic (✓ / ▲ / ⚑▲ / !!⚑▲) previously inlined in `messages.py`.
- `config/sarc-ref.yaml`: documented `files:write` as a required Slack bot scope alongside the existing `chat:write`, `im:write`, `users:read.email`.
- Tests: new `test_csv_export.py`; added coverage for `upload_files` and the CSV upload/failure/dry-run paths in `test_cli.py`; updated `test_recurring.py` call sites for the `get_recurring_underusers` / `select_recurring_table_view` split; dropped the removed `cluster_share_threshold` arg in `test_usage_refresh_store.py`.

## Notes
- Requires the `files:write` Slack bot scope in addition to the existing `chat:write`, `im:write`, `users:read.email`.