### PR TITLE
Use Numpy instead of Pandas to compute Prometheus stats, and fix NaN (division by zero) on system_memory

### DIFF
--- a/sarc/scraping/series.py
+++ b/sarc/scraping/series.py
@@ -149,9 +149,9 @@ def _counter_rates(results: Sequence[dict]) -> np.ndarray | None:
 
     Series are grouped by their (instance, core, gpu) labels — series sharing
     the same labels are concatenated in input order — and each group is
-    differenced separately. Returns None when no real sample survives the
-    sentinel filter, and an empty array when the groups are all too short to
-    difference (statistics then come out NaN).
+    differenced separately. Returns None when no attributable real sample
+    survives the sentinel filter, and an empty array when the groups are all
+    too short to difference (statistics then come out NaN).
     """
     used = [k for k in _COUNTER_GROUP_LABELS if any(k in s["metric"] for s in results)]
     groups: dict[tuple, list[tuple[np.ndarray, np.ndarray]]] = {}
@@ -304,7 +304,7 @@ def compute_job_statistics(
         # A zero allocation cannot normalize anything: skip system_memory
         # instead of dividing by zero.
         logger.warning(
-            f"job.allocated.mem is None or 0 for job {job.job_id} (job status: {job.job_state.value})"
+            f"job.allocated_mem is None or 0 for job {job.job_id} (job status: {job.job_state.value})"
         )
 
     res = dict()

--- a/sarc/scraping/series.py
+++ b/sarc/scraping/series.py
@@ -144,18 +144,16 @@ def _filtered_points(series: dict) -> tuple[np.ndarray, np.ndarray]:
     return timestamps[keep], values[keep]
 
 
-def _counter_rates(results: Sequence[dict]) -> np.ndarray | None:
+def _counter_rates(results: Sequence[dict]) -> np.ndarray:
     """Pooled per-second rates of a nanosecond time counter (e.g. core usage).
 
     Series are grouped by their (instance, core, gpu) labels — series sharing
     the same labels are concatenated in input order — and each group is
-    differenced separately. Returns None when no attributable real sample
-    survives the sentinel filter, and an empty array when the groups are all
-    too short to difference (statistics then come out NaN).
+    differenced separately. The result is empty when no group has at least
+    two attributable real samples.
     """
     used = [k for k in _COUNTER_GROUP_LABELS if any(k in s["metric"] for s in results)]
     groups: dict[tuple, list[tuple[np.ndarray, np.ndarray]]] = {}
-    n_samples = 0
     for series in results:
         labels = series["metric"]
         try:
@@ -163,11 +161,8 @@ def _counter_rates(results: Sequence[dict]) -> np.ndarray | None:
         except KeyError:
             continue  # a group label is missing: these samples are not attributable
         timestamps, values = _filtered_points(series)
-        n_samples += values.size
         if values.size:
             groups.setdefault(key, []).append((timestamps, values))
-    if n_samples == 0:
-        return None
     rates = []
     for chunks in groups.values():
         timestamps = np.concatenate([c[0] for c in chunks])
@@ -203,23 +198,10 @@ def compute_metric_statistics(
         return None
     if is_time_counter:
         values = _counter_rates(results)
-        if values is None:
-            return None
-        if values.size == 0:
-            nan = normalization(math.nan)
-            return {
-                "mean": nan,
-                "std": nan,
-                "max": nan,
-                "q25": nan,
-                "median": nan,
-                "q75": nan,
-                "q05": nan,
-            }
     else:
         values = np.concatenate([_filtered_points(s)[1] for s in results])
-        if values.size == 0:
-            return None
+    if values.size == 0:
+        return None
     std = float(np.std(values, ddof=1)) if values.size >= 2 else math.nan
     q05, q25, median, q75 = map(float, np.quantile(values, (0.05, 0.25, 0.5, 0.75)))
     return {

--- a/sarc/scraping/series.py
+++ b/sarc/scraping/series.py
@@ -293,7 +293,7 @@ def compute_job_statistics(
     )
 
     system_memory = None
-    if job.allocated_mem is not None:
+    if job.allocated_mem:
         # NB: slurm_job_memory_usage is expressed in bytes
         # job.allocated_mem is in megabytes (multiple of 2**20 bytes)
         system_memory = compute_metric_statistics(
@@ -301,8 +301,10 @@ def compute_job_statistics(
             normalization=lambda x: float(x / (2**20) / cast(int, job.allocated_mem)),
         )
     elif metric_to_data["slurm_job_memory_usage"]:
+        # A zero allocation cannot normalize anything: skip system_memory
+        # instead of dividing by zero.
         logger.warning(
-            f"job.allocated.mem is None for job {job.job_id} (job status: {job.job_state.value})"
+            f"job.allocated.mem is None or 0 for job {job.job_id} (job status: {job.job_state.value})"
         )
 
     res = dict()

--- a/sarc/scraping/series.py
+++ b/sarc/scraping/series.py
@@ -1,9 +1,9 @@
 import logging
+import math
 from datetime import datetime
 from typing import Callable, Sequence, TypedDict, cast
 
-from pandas import DataFrame, Series
-from prometheus_api_client.metric_range_df import MetricRangeDataFrame
+import numpy as np
 
 from sarc.config import UTC, config
 from sarc.db.job import JobStatisticDB, SlurmJobDB
@@ -124,40 +124,117 @@ STATS = TypedDict(
 )
 
 
+# Labels that identify one physical source (node, CPU core, GPU) within a
+# job's series; time counters are differenced per source.
+_COUNTER_GROUP_LABELS = ("instance", "core", "gpu")
+
+
+def _filtered_points(series: dict) -> tuple[np.ndarray, np.ndarray]:
+    """Timestamps and values of one raw Prometheus series, real samples only.
+
+    Drops the DCGM BLANK sentinels (2**47 and the NOT_FOUND/NOT_SUPPORTED/
+    NOT_PERMISSIONED variants) that the GPU exporter forwards untouched when a
+    metric is unavailable, as well as NaN samples: any comparison with NaN is
+    False, so `value < DCGM_FP64_BLANK` discards both.
+    """
+    points = series["values"]
+    timestamps = np.fromiter((p[0] for p in points), dtype=float, count=len(points))
+    values = np.array([p[1] for p in points], dtype=float)
+    keep = values < DCGM_FP64_BLANK
+    return timestamps[keep], values[keep]
+
+
+def _counter_rates(results: Sequence[dict]) -> np.ndarray | None:
+    """Pooled per-second rates of a nanosecond time counter (e.g. core usage).
+
+    Series are grouped by their (instance, core, gpu) labels — series sharing
+    the same labels are concatenated in input order — and each group is
+    differenced separately. Returns None when no real sample survives the
+    sentinel filter, and an empty array when the groups are all too short to
+    difference (statistics then come out NaN).
+    """
+    used = [k for k in _COUNTER_GROUP_LABELS if any(k in s["metric"] for s in results)]
+    groups: dict[tuple, list[tuple[np.ndarray, np.ndarray]]] = {}
+    n_samples = 0
+    for series in results:
+        labels = series["metric"]
+        try:
+            key = tuple(labels[k] for k in used)
+        except KeyError:
+            continue  # a group label is missing: these samples are not attributable
+        timestamps, values = _filtered_points(series)
+        n_samples += values.size
+        if values.size:
+            groups.setdefault(key, []).append((timestamps, values))
+    if n_samples == 0:
+        return None
+    rates = []
+    for chunks in groups.values():
+        timestamps = np.concatenate([c[0] for c in chunks])
+        values = np.concatenate([c[1] for c in chunks])
+        if values.size >= 2:
+            # 1-nanosecond resolution, like the cpu counters in /proc/stat.
+            rates.append(np.diff(values) / np.diff(timestamps) / 1e9)
+    return np.concatenate(rates) if rates else np.empty(0)
+
+
 @trace_decorator()
-def compute_job_statistics_from_dataframe(
-    df: DataFrame | None,
-    statistics: dict[str, Callable[[Series], float]],
+def compute_metric_statistics(
+    results: Sequence[dict],
     normalization: Callable[[float], float] = float,
     is_time_counter: bool = False,
 ) -> STATS | None:
-    if df is None:
+    """Compute the stored statistics of one metric's raw Prometheus series.
+
+    Arguments:
+        results: The raw `custom_query` result list for a single metric:
+            dicts with a "metric" labels mapping and a "values" list of
+            [timestamp, value] samples.
+        normalization: Applied to each computed statistic.
+        is_time_counter: The metric is a monotonic nanosecond counter:
+            statistics are computed on its per-second rate instead of its
+            raw values.
+
+    Values are pooled across all the metric's series. Returns None when no
+    usable sample remains. std uses ddof=1 (NaN for a single sample) and
+    quantiles interpolate linearly, matching the former pandas reductions.
+    """
+    if not results:
         return None
-
-    df = df.reset_index()
-
-    # Drop DCGM BLANK sentinels (2**47 and the NOT_FOUND/NOT_SUPPORTED/
-    # NOT_PERMISSIONED variants) that the GPU exporter forwards untouched
-    # when a metric is unavailable; otherwise they pollute mean/max/quantiles.
-    df = df[df["value"] < DCGM_FP64_BLANK]
-    if df.empty:
-        return None
-
-    groupby = ["instance", "core", "gpu"]
-    groupby = [col for col in groupby if col in df]
-
-    gdf = df.groupby(groupby)
-
     if is_time_counter:
-        # This is a time-based counter like the cpu counters in /proc/stat, with
-        # a resolution of 1 nanosecond.
-        timediffs = gdf["timestamp"].diff().map(lambda x: x.total_seconds())  # ty:ignore[unresolved-attribute]
-        df["value"] = gdf["value"].diff() / timediffs / 1e9
-        df = df.drop(index=0)
-        # Recompute groupby after modifying df
-        gdf = df.groupby(groupby)
+        values = _counter_rates(results)
+        if values is None:
+            return None
+        if values.size == 0:
+            nan = normalization(math.nan)
+            return {
+                "mean": nan,
+                "std": nan,
+                "max": nan,
+                "q25": nan,
+                "median": nan,
+                "q75": nan,
+                "q05": nan,
+            }
+    else:
+        values = np.concatenate([_filtered_points(s)[1] for s in results])
+        if values.size == 0:
+            return None
+    std = float(np.std(values, ddof=1)) if values.size >= 2 else math.nan
+    q05, q25, median, q75 = map(float, np.quantile(values, (0.05, 0.25, 0.5, 0.75)))
+    return {
+        "mean": normalization(float(np.mean(values))),
+        "std": normalization(std),
+        "max": normalization(float(np.max(values))),
+        "q25": normalization(q25),
+        "median": normalization(median),
+        "q75": normalization(q75),
+        "q05": normalization(q05),
+    }
 
-    return {name: normalization(fn(df["value"])) for name, fn in statistics.items()}  # ty:ignore[invalid-return-type]
+
+def _percent(x: float) -> float:
+    return float(x / 100)
 
 
 JOB_STATISTICS_METRIC_NAMES = (
@@ -177,87 +254,53 @@ JOB_STATISTICS_METRIC_NAMES = (
 def compute_job_statistics(
     job: SlurmJobDB, prom_stats: list[dict]
 ) -> dict[str, JobStatisticDB]:
-    statistics_dict: dict[str, Callable[[Series], float]] = {
-        "mean": lambda self: self.mean(),
-        "std": lambda self: self.std(),
-        "max": lambda self: self.max(),
-        "q25": lambda self: self.quantile(0.25),
-        "median": lambda self: self.median(),
-        "q75": lambda self: self.quantile(0.75),
-        "q05": lambda self: self.quantile(0.05),
-    }
-
-    # We will get all required job time series
-    # with just 1 call to get_job_time_series()
+    # We get all required job time series with just 1 call to
+    # get_job_time_series(), then split them by metric.
     metric_to_data: dict[str, list[dict]] = {
         metric: [] for metric in JOB_STATISTICS_METRIC_NAMES
     }
     for result in prom_stats:
         metric_to_data[result["metric"]["__name__"]].append(result)
-    # Then we convert series to data frames for each metric
-    metrics = {
-        metric: MetricRangeDataFrame(results) if results else None
-        for metric, results in metric_to_data.items()
-    }
-    # Now we can use data frames to compute statistics for each metric,
-    # by directly using compute_job_statistics_from_dataframe().
 
-    gpu_utilization = compute_job_statistics_from_dataframe(
-        metrics["slurm_job_utilization_gpu"],
-        statistics=statistics_dict,
-        normalization=lambda x: float(x / 100),
+    gpu_utilization = compute_metric_statistics(
+        metric_to_data["slurm_job_utilization_gpu"], normalization=_percent
     )
 
-    gpu_utilization_fp16 = compute_job_statistics_from_dataframe(
-        metrics["slurm_job_fp16_gpu"],
-        statistics=statistics_dict,
-        normalization=lambda x: float(x / 100),
+    gpu_utilization_fp16 = compute_metric_statistics(
+        metric_to_data["slurm_job_fp16_gpu"], normalization=_percent
     )
 
-    gpu_utilization_fp32 = compute_job_statistics_from_dataframe(
-        metrics["slurm_job_fp32_gpu"],
-        statistics=statistics_dict,
-        normalization=lambda x: float(x / 100),
+    gpu_utilization_fp32 = compute_metric_statistics(
+        metric_to_data["slurm_job_fp32_gpu"], normalization=_percent
     )
 
-    gpu_utilization_fp64 = compute_job_statistics_from_dataframe(
-        metrics["slurm_job_fp64_gpu"],
-        statistics=statistics_dict,
-        normalization=lambda x: float(x / 100),
+    gpu_utilization_fp64 = compute_metric_statistics(
+        metric_to_data["slurm_job_fp64_gpu"], normalization=_percent
     )
 
-    gpu_sm_occupancy = compute_job_statistics_from_dataframe(
-        metrics["slurm_job_sm_occupancy_gpu"],
-        statistics=statistics_dict,
-        normalization=lambda x: float(x / 100),
+    gpu_sm_occupancy = compute_metric_statistics(
+        metric_to_data["slurm_job_sm_occupancy_gpu"], normalization=_percent
     )
 
-    gpu_memory = compute_job_statistics_from_dataframe(
-        metrics["slurm_job_utilization_gpu_memory"],
-        statistics=statistics_dict,
-        normalization=lambda x: float(x / 100),
+    gpu_memory = compute_metric_statistics(
+        metric_to_data["slurm_job_utilization_gpu_memory"], normalization=_percent
     )
 
-    gpu_power = compute_job_statistics_from_dataframe(
-        metrics["slurm_job_power_gpu"], statistics=statistics_dict
-    )
+    gpu_power = compute_metric_statistics(metric_to_data["slurm_job_power_gpu"])
 
-    cpu_utilization = compute_job_statistics_from_dataframe(
-        metrics["slurm_job_core_usage"],
-        statistics=statistics_dict,
-        is_time_counter=True,
+    cpu_utilization = compute_metric_statistics(
+        metric_to_data["slurm_job_core_usage"], is_time_counter=True
     )
 
     system_memory = None
     if job.allocated_mem is not None:
         # NB: slurm_job_memory_usage is expressed in bytes
         # job.allocated_mem is in megabytes (multiple of 2**20 bytes)
-        system_memory = compute_job_statistics_from_dataframe(
-            metrics["slurm_job_memory_usage"],
-            statistics=statistics_dict,
+        system_memory = compute_metric_statistics(
+            metric_to_data["slurm_job_memory_usage"],
             normalization=lambda x: float(x / (2**20) / cast(int, job.allocated_mem)),
         )
-    elif metrics["slurm_job_memory_usage"] is not None:
+    elif metric_to_data["slurm_job_memory_usage"]:
         logger.warning(
             f"job.allocated.mem is None for job {job.job_id} (job status: {job.job_state.value})"
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -241,9 +241,11 @@ read_write_db_config_object = DbConfiguration("rw").fixture()
 
 read_write_db_with_many_cpu_jobs_config_object = DbConfiguration(
     "r-jobs",
+    # CPU-only jobs: no GPU, but a real memory allocation (factory default), so
+    # computed statistics include a genuine system_memory entry.
     job_patch={
-        "allocated": {"billing": 0, "cpu": 0, "gres_gpu": 0, "mem": 0, "node": 0},
-        "requested": {"billing": 0, "cpu": 0, "gres_gpu": 0, "mem": 0, "node": 0},
+        "allocated": {"billing": 0, "cpu": 0, "gres_gpu": 0, "node": 0},
+        "requested": {"billing": 0, "cpu": 0, "gres_gpu": 0, "node": 0},
     },
 ).fixture()
 

--- a/tests/unittests/jobs/test_series.py
+++ b/tests/unittests/jobs/test_series.py
@@ -1,8 +1,7 @@
-from datetime import datetime, timedelta
+import math
+from datetime import UTC, datetime
 
-import pandas
 import pytest
-from pandas import DataFrame
 
 from sarc.scraping.dcgm import (
     DCGM_FP64_BLANK,
@@ -10,60 +9,97 @@ from sarc.scraping.dcgm import (
     DCGM_FP64_NOT_PERMISSIONED,
     DCGM_FP64_NOT_SUPPORTED,
 )
-from sarc.scraping.series import compute_job_statistics_from_dataframe
+from sarc.scraping.series import compute_metric_statistics
+
+T0 = int(datetime(2023, 1, 1, tzinfo=UTC).timestamp())
 
 
-def _generate_df(rows, delta=30):
-    t0 = datetime(2023, 1, 1)
-    df = DataFrame(
-        {"timestamp": t0 + timedelta(seconds=i * delta), **row}
-        for i, row in enumerate(rows)
-    )
-    return df.set_index("timestamp")
+def _series(values, delta=30, **labels):
+    """One raw Prometheus series as returned by custom_query."""
+    return {
+        "metric": {"__name__": "some_metric", **labels},
+        "values": [[T0 + i * delta, str(v)] for i, v in enumerate(values)],
+    }
 
 
-def test_compute_job_statistics_from_dataframe(captrace):
-    rows = [{"instance": "cn-c002", "value": i} for i in range(100)]
-    df = _generate_df(rows)
-    stats = compute_job_statistics_from_dataframe(
-        df, {"mean": lambda self: self.mean()}
-    )
-    assert stats == {"mean": 99 / 2}
+def test_compute_metric_statistics(captrace):
+    stats = compute_metric_statistics([_series(range(100), instance="cn-c002")])
+    assert stats == {
+        "mean": 99 / 2,
+        "std": pytest.approx(29.011491975882016),
+        "max": 99.0,
+        "q05": pytest.approx(4.95),
+        "q25": pytest.approx(24.75),
+        "median": 99 / 2,
+        "q75": pytest.approx(74.25),
+    }
 
     # Check trace
     spans = captrace.get_finished_spans()
     assert len(spans) == 1
-    assert spans[0].name == "compute_job_statistics_from_dataframe"
+    assert spans[0].name == "compute_metric_statistics"
 
 
-def test_compute_job_statistics_from_dataframe_normalization():
-    rows = [{"instance": "cn-c002", "value": i} for i in range(100)]
-    df = _generate_df(rows)
-    stats = compute_job_statistics_from_dataframe(
-        df, {"mean": lambda self: self.mean()}, normalization=lambda x: x * 10
+def test_compute_metric_statistics_no_series():
+    assert compute_metric_statistics([]) is None
+
+
+def test_compute_metric_statistics_normalization():
+    stats = compute_metric_statistics(
+        [_series(range(100), instance="cn-c002")], normalization=lambda x: x * 10
     )
-    assert stats == {"mean": 10 * 99 / 2}
+    assert stats["mean"] == 10 * 99 / 2
+
+
+def test_compute_metric_statistics_single_sample_std_is_nan():
+    stats = compute_metric_statistics([_series([5.0], instance="cn-c002")])
+    assert stats["mean"] == 5.0
+    assert math.isnan(stats["std"])
 
 
 @pytest.mark.parametrize(["delta"], [[30], [60]])
-def test_compute_job_statistics_from_dataframe_time_counter(delta):
-    rows1 = [{"instance": "cn-c002", "value": 75e9 * i} for i in range(100)]
-    rows2 = [{"instance": "cn-c007", "value": 15e9 * i} for i in range(100)]
-    df1 = _generate_df(rows1, delta=delta)
-    df2 = _generate_df(rows2, delta=delta)
+def test_compute_metric_statistics_time_counter(delta):
+    # Two sources counting at different paces: rates must be computed per
+    # (instance, core) series, then pooled.
+    results = [
+        _series(
+            [75e9 * i for i in range(100)], delta=delta, instance="cn-c002", core="0"
+        ),
+        _series(
+            [15e9 * i for i in range(100)], delta=delta, instance="cn-c007", core="0"
+        ),
+    ]
+    stats = compute_metric_statistics(results, is_time_counter=True)
+    assert stats["mean"] == (75 / delta + 15 / delta) / 2
 
-    # The two series are interleaved in the data, but the function will
-    # have to group by instance before taking the mean
-    df = pandas.concat([df1, df2])
-    df = df.sort_values(by="timestamp")
 
-    stats = compute_job_statistics_from_dataframe(
-        df, {"mean": lambda self: self.mean()}, is_time_counter=True
+def test_compute_metric_statistics_time_counter_same_labels_concatenated():
+    # Two chunks of the same source (identical labels) must be differenced as
+    # one series, including across the chunk boundary.
+    results = [
+        _series([0.0, 30e9], instance="cn-c002", core="0"),
+        {
+            "metric": {"__name__": "some_metric", "instance": "cn-c002", "core": "0"},
+            "values": [[T0 + 60, "90e9"], [T0 + 90, "150e9"]],
+        },
+    ]
+    stats = compute_metric_statistics(results, is_time_counter=True)
+    # rates: 1.0 within the first chunk, 2.0 across the boundary, 2.0 within
+    # the second chunk.
+    assert stats["mean"] == (1.0 + 2.0 + 2.0) / 3
+
+
+def test_compute_metric_statistics_time_counter_too_short_gives_nan():
+    # Single-sample sources cannot be differenced: statistics exist but are
+    # all NaN (behavior inherited from the pandas implementation).
+    stats = compute_metric_statistics(
+        [_series([5e9], instance="cn-c002", core="0")], is_time_counter=True
     )
-    assert stats == {"mean": (75 / delta + 15 / delta) / 2}
+    assert stats is not None
+    assert all(math.isnan(v) for v in stats.values())
 
 
-def test_compute_job_statistics_from_dataframe_filters_dcgm_blank():
+def test_compute_metric_statistics_filters_dcgm_blank():
     # Mix of valid values and DCGM sentinels (BLANK + the three error
     # variants). All sentinels must be discarded so that stats reflect only
     # the valid samples.
@@ -73,18 +109,23 @@ def test_compute_job_statistics_from_dataframe_filters_dcgm_blank():
         DCGM_FP64_NOT_SUPPORTED,
         DCGM_FP64_NOT_PERMISSIONED,
     ]
-    rows = [{"instance": "cn-c002", "value": v} for v in [1.0, 2.0, 3.0, *sentinels]]
-    df = _generate_df(rows)
-    stats = compute_job_statistics_from_dataframe(
-        df, {"mean": lambda self: self.mean(), "max": lambda self: self.max()}
+    stats = compute_metric_statistics(
+        [_series([1.0, 2.0, 3.0, *sentinels], instance="cn-c002")]
     )
-    assert stats == {"mean": 2.0, "max": 3.0}
+    assert stats["mean"] == 2.0
+    assert stats["max"] == 3.0
 
 
-def test_compute_job_statistics_from_dataframe_all_blank_returns_none():
-    rows = [{"instance": "cn-c002", "value": DCGM_FP64_BLANK} for _ in range(5)]
-    df = _generate_df(rows)
-    stats = compute_job_statistics_from_dataframe(
-        df, {"mean": lambda self: self.mean()}
+def test_compute_metric_statistics_filters_nan_samples():
+    stats = compute_metric_statistics(
+        [_series([1.0, float("nan"), 3.0], instance="cn-c002")]
+    )
+    assert stats["mean"] == 2.0
+    assert stats["max"] == 3.0
+
+
+def test_compute_metric_statistics_all_blank_returns_none():
+    stats = compute_metric_statistics(
+        [_series([DCGM_FP64_BLANK] * 5, instance="cn-c002")]
     )
     assert stats is None

--- a/tests/unittests/jobs/test_series.py
+++ b/tests/unittests/jobs/test_series.py
@@ -173,4 +173,4 @@ def test_compute_job_statistics_without_allocated_mem(mem, caplog):
     with caplog.at_level(logging.WARNING):
         stats = compute_job_statistics(job, [memory_series])
     assert stats == {}
-    assert f"job.allocated.mem is None or 0 for job {job.job_id}" in caplog.text
+    assert f"job.allocated_mem is None or 0 for job {job.job_id}" in caplog.text

--- a/tests/unittests/jobs/test_series.py
+++ b/tests/unittests/jobs/test_series.py
@@ -1,25 +1,37 @@
+import logging
 import math
 from datetime import UTC, datetime
 
 import pytest
 
+from sarc.db.job import SlurmJobDB
+from sarc.models.job import SlurmState
 from sarc.scraping.dcgm import (
     DCGM_FP64_BLANK,
     DCGM_FP64_NOT_FOUND,
     DCGM_FP64_NOT_PERMISSIONED,
     DCGM_FP64_NOT_SUPPORTED,
 )
-from sarc.scraping.series import compute_metric_statistics
+from sarc.scraping.series import compute_job_statistics, compute_metric_statistics
+from tests.db.factory import base_job
 
 T0 = int(datetime(2023, 1, 1, tzinfo=UTC).timestamp())
 
 
-def _series(values, delta=30, **labels):
+def _series(values, delta=30, name="some_metric", **labels):
     """One raw Prometheus series as returned by custom_query."""
     return {
-        "metric": {"__name__": "some_metric", **labels},
+        "metric": {"__name__": name, **labels},
         "values": [[T0 + i * delta, str(v)] for i, v in enumerate(values)],
     }
+
+
+def _job(**patch):
+    """A detached SlurmJobDB built from the factory's base fields."""
+    fields = {k: v for k, v in base_job.items() if k != "cluster_name"}
+    fields.update(cluster_id=1, sarc_user_id=1, job_state=SlurmState.CANCELLED)
+    fields.update(patch)
+    return SlurmJobDB(**fields)
 
 
 def test_compute_metric_statistics(captrace):
@@ -99,6 +111,25 @@ def test_compute_metric_statistics_time_counter_too_short_gives_nan():
     assert all(math.isnan(v) for v in stats.values())
 
 
+def test_compute_metric_statistics_time_counter_all_blank_returns_none():
+    stats = compute_metric_statistics(
+        [_series([DCGM_FP64_BLANK] * 5, instance="cn-c002", core="0")],
+        is_time_counter=True,
+    )
+    assert stats is None
+
+
+def test_compute_metric_statistics_time_counter_unlabeled_series_ignored():
+    # The second series lacks the (instance, core) group labels used by this
+    # metric: its samples cannot be attributed to a source and are dropped.
+    results = [
+        _series([0.0, 30e9], instance="cn-c002", core="0"),  # rate 1.0
+        _series([0.0, 999e9]),
+    ]
+    stats = compute_metric_statistics(results, is_time_counter=True)
+    assert stats["mean"] == 1.0
+
+
 def test_compute_metric_statistics_filters_dcgm_blank():
     # Mix of valid values and DCGM sentinels (BLANK + the three error
     # variants). All sentinels must be discarded so that stats reflect only
@@ -129,3 +160,17 @@ def test_compute_metric_statistics_all_blank_returns_none():
         [_series([DCGM_FP64_BLANK] * 5, instance="cn-c002")]
     )
     assert stats is None
+
+
+@pytest.mark.parametrize("mem", [0, None])
+def test_compute_job_statistics_without_allocated_mem(mem, caplog):
+    # A None or zero allocation cannot normalize memory usage: no
+    # system_memory statistic, and a warning is logged.
+    job = _job(allocated_mem=mem)
+    memory_series = _series(
+        [1e9, 2e9], name="slurm_job_memory_usage", instance="cn-c002"
+    )
+    with caplog.at_level(logging.WARNING):
+        stats = compute_job_statistics(job, [memory_series])
+    assert stats == {}
+    assert f"job.allocated.mem is None or 0 for job {job.job_id}" in caplog.text

--- a/tests/unittests/jobs/test_series.py
+++ b/tests/unittests/jobs/test_series.py
@@ -101,14 +101,13 @@ def test_compute_metric_statistics_time_counter_same_labels_concatenated():
     assert stats["mean"] == (1.0 + 2.0 + 2.0) / 3
 
 
-def test_compute_metric_statistics_time_counter_too_short_gives_nan():
-    # Single-sample sources cannot be differenced: statistics exist but are
-    # all NaN (behavior inherited from the pandas implementation).
+def test_compute_metric_statistics_time_counter_too_short_returns_none():
+    # Single-sample sources cannot be differenced: no rate, no statistics
+    # (the former pandas implementation stored all-NaN statistics instead).
     stats = compute_metric_statistics(
         [_series([5e9], instance="cn-c002", core="0")], is_time_counter=True
     )
-    assert stats is not None
-    assert all(math.isnan(v) for v in stats.values())
+    assert stats is None
 
 
 def test_compute_metric_statistics_time_counter_all_blank_returns_none():


### PR DESCRIPTION
- Speed-up: replace Pandas with Numpy to compute Prometheus statistics
- Fix: fix NaN (division by zero) when computing system_memory: job allocated_mem may be zero, so dividing Prometheus memory usage by allocated_mem may produce NaN (in Pandas) or a division by zero error (in Numpy)