### PR TITLE
Dashboard multi fixes

### DIFF
--- a/sarc/api/metrics.html
+++ b/sarc/api/metrics.html
@@ -1667,6 +1667,12 @@
       const fmtRguTime = v => v != null
         ? (v * unit.factor).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
         : '—';
+
+      const unitHour = RGU_UNITS.h;
+      const fmtRguHour = v => v != null
+        ? (v * unitHour.factor).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
+        : '—';
+
       // submit_time arrives as an ISO string; show it in UTC (YYYY-MM-DD HH:MM)
       // to match the dashboard's UTC date range / focus.
       const fmtDateTime = v => {
@@ -1694,9 +1700,19 @@
         { key: 'rgu_hours',             label: unit.label,
           title: `RGU × elapsed time, shown in ${unit.label}`,
           fmt: fmtRguTime },
+
+        { key: 'rgu_hours',             label: unitHour.label,
+          title: `RGU × elapsed time, shown in ${unitHour.label}`,
+          fmt: fmtRguHour },
+
         { key: 'waste',                 label: `Waste (${unit.label})`,
           title: `RGU·time × (1 − mean ${metricPretty}): estimated unused RGU·time`,
           fmt: fmtRguTime },
+
+        { key: 'waste',                 label: `Waste (${unitHour.label})`,
+          title: `RGU·time × (1 − mean ${metricPretty}): estimated unused RGU·time`,
+          fmt: fmtRguHour },
+
         { key: 'gpu_sm_occupancy_mean', label: 'SM occ',    fmt: v => v != null ? (v < 0 ? 'NaN' : (v*100).toFixed(1)+'%') : '—' },
         { key: 'gpu_utilization_mean',  label: 'GPU util',  fmt: v => v != null ? (v < 0 ? 'NaN' : (v*100).toFixed(1)+'%') : '—' },
         { key: 'gpu_type',              label: 'GPU type' },

--- a/sarc/api/metrics.html
+++ b/sarc/api/metrics.html
@@ -1676,10 +1676,11 @@
         { key: 'rgu_hours',             label: unit.label,
           title: `RGU × elapsed time, shown in ${unit.label}`,
           fmt: fmtRguTime },
-        { key: 'gpu_sm_occupancy_mean', label: 'SM occ',    fmt: v => v != null ? (v*100).toFixed(1)+'%' : '—' },
         { key: 'waste',                 label: `Waste (${unit.label})`,
           title: `RGU·time × (1 − mean ${metricPretty}): estimated unused RGU·time`,
           fmt: fmtRguTime },
+        { key: 'gpu_sm_occupancy_mean', label: 'SM occ',    fmt: v => v != null ? (v*100).toFixed(1)+'%' : '—' },
+        { key: 'gpu_utilization_mean',  label: 'GPU util',  fmt: v => v != null ? (v*100).toFixed(1)+'%' : '—' },
         { key: 'gpu_type',              label: 'GPU type' },
         {% if is_admin %}
         { key: 'gpu_type_rgu',          label: 'GPU type RGU',
@@ -1693,7 +1694,6 @@
         { key: 'allocated_gpu',         label: 'Allocated GPU', fmt: fmtInt },
         {% if is_admin %}
         { key: 'billing',               label: 'Billing',   fmt: fmtInt },
-        { key: 'gpu_utilization_mean',  label: 'GPU util',  fmt: v => v != null ? (v*100).toFixed(1)+'%' : '—' },
         { key: 'gpu_memory_max',        label: 'Mem max',   fmt: v => v != null ? (v*100).toFixed(1)+'%' : '—' },
         {% endif %}
         { key: 'nodes',                 label: 'Nodes',     cls: 'col-cmd' },

--- a/sarc/api/metrics.html
+++ b/sarc/api/metrics.html
@@ -178,6 +178,12 @@
     .job-table th.sort-desc::after { content: ' ▼'; font-size: 10px; }
     .job-table td { padding: 4px 8px; border-bottom: 1px solid #eee; vertical-align: middle; }
     .job-table tr:hover td { background: #f4f6ff; }
+    /* Usage shading (thresholds: MIN_USAGE_EXPECTED_PERCENT / CRITICAL_USAGE_PERCENT):
+       light red below the expected minimum, stronger red below the critical bar. */
+    .job-table tr.jt-low td  { background: #ffefef; }
+    .job-table tr.jt-crit td { background: #ffcccc; }
+    .job-table tr.jt-low:hover td  { background: #ffe2e2; }
+    .job-table tr.jt-crit:hover td { background: #ffbdbd; }
     .job-table .col-cmd {
       max-width: 100px; overflow: hidden; text-overflow: ellipsis;
       white-space: nowrap; font-family: monospace; font-size: 11px; color: #555;
@@ -382,6 +388,10 @@
     // the per-job wasted-RGU shortfall, computed server-side) and shown in the
     // Wasted/Unused bar labels.
     const MIN_USAGE_EXPECTED_PERCENT = 15;
+
+    // Below this, usage is critically low: the job table shades those rows a
+    // stronger red (vs light red between here and MIN_USAGE_EXPECTED_PERCENT).
+    const CRITICAL_USAGE_PERCENT = 5;
 
     // Temporary user-guide target (Google Doc), linked from inside the "ⓘ"
     // help panel on the RGU-usage tiles.
@@ -1835,7 +1845,9 @@
         `GPU jobs ${from.toLocaleString('en-US')}–${to.toLocaleString('en-US')} `
         + `of ${total.toLocaleString('en-US')}`;
       capText.title = 'Only GPU jobs (allocated GPU with a known RGU) are listed; '
-        + 'CPU-only jobs are counted in the per-period bar plot but not here.';
+        + 'CPU-only jobs are counted in the per-period bar plot but not here. '
+        + `Red rows: mean ${metricPretty} below the ${MIN_USAGE_EXPECTED_PERCENT} % `
+        + `expected minimum (stronger red: below ${CRITICAL_USAGE_PERCENT} %).`;
       caption.appendChild(capText);
 
       const wrap = document.createElement('div');
@@ -1877,6 +1889,16 @@
       const tbody = tbl.createTBody();
       jobList.forEach(job => {
         const tr = tbody.insertRow();
+        // Shade under-using rows (measured jobs only): the same per-job mean
+        // that feeds the Unused columns, so table and bars tell one story.
+        const mm = job.metric_mean;
+        if (mm != null && mm < MIN_USAGE_EXPECTED_PERCENT / 100) {
+          const crit = mm < CRITICAL_USAGE_PERCENT / 100;
+          tr.className = crit ? 'jt-crit' : 'jt-low';
+          tr.title = `Mean ${metricPretty}: ${(mm * 100).toFixed(1)} % — `
+            + (crit ? `critically low (below ${CRITICAL_USAGE_PERCENT} %)`
+                    : `below the ${MIN_USAGE_EXPECTED_PERCENT} % expected minimum`);
+        }
         COLS.forEach(c => {
           const td = tr.insertCell();
           td.dataset.col = c.key;

--- a/sarc/api/metrics.html
+++ b/sarc/api/metrics.html
@@ -173,13 +173,15 @@
 
     /* Job table */
     .job-table-box { display: flex; flex-direction: column; width: 100%; height: 100%; }
-    .job-table-caption {
-      flex-shrink: 0; font-size: 12px; color: #888; padding: 2px 0 6px;
-      display: flex; align-items: center; gap: 8px;
+    /* Job-table header slot: the jobs-count label + column picker share the
+       tile-header line, left-aligned after the title (the tile controls keep
+       the right edge); flex:1 absorbs the label's variable width. */
+    .jt-head-slot {
+      flex: 1; min-width: 0; display: flex; align-items: center; gap: 10px;
+      margin-left: 12px; font-size: 12px; font-weight: 400; color: #888;
     }
-    .job-table-caption .jt-cols { margin-left: auto; }     /* push the column picker to the right */
-    .job-table-caption .add-select { padding: 1px 6px; font-size: 11px; }
-    .jt-cols-panel { right: 0; }                            /* anchor the panel to the right edge */
+    .jt-head-slot .jt-caption-text { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .jt-head-slot .add-select { padding: 1px 6px; font-size: 11px; }
     .job-table-wrap { width: 100%; flex: 1; min-height: 0; overflow: auto; }
     .job-table { width: 100%; border-collapse: collapse; font-size: 13px; }
     .job-table th {
@@ -230,6 +232,9 @@
     .job-table-foot .jt-page-link {
       color: #1a6fd4; cursor: pointer; text-decoration: underline;
       text-underline-offset: 2px;
+      /* Right-aligned in a box reserved (via inline min-width, in ch) for the
+         largest page number, so 'Page X / N' never shifts as X gains digits. */
+      display: inline-block; text-align: right;
     }
     .job-table-foot .jt-page-link:hover { color: #155cb5; }
     /* Page-jump popover, anchored above the page link (opens upward so it is
@@ -241,7 +246,6 @@
       display: flex; flex-direction: column; gap: 6px; align-items: stretch;
     }
     .jt-page-pop button { padding: 2px 0; }
-    .job-table-foot .jt-spacer { flex: 1; }
     /* "Loading" cue shown in the caption while a page is being (re)fetched:
        bold + italic + accent colour, a gentle opacity pulse, and animated
        trailing dots via ::after. The class is added in reload() and cleared
@@ -1020,6 +1024,13 @@
             title.appendChild(makeRguUsageHelp());
           }
           header.appendChild(title);
+          if (plotType === 'jobtable') {
+            // Slot the job-table renderer fills with the jobs-count label +
+            // column picker, so they share the header line (one row saved).
+            const slot = document.createElement('span');
+            slot.className = 'jt-head-slot';
+            header.appendChild(slot);
+          }
           {% if is_admin %}
           const actions = document.createElement('span');
           actions.style.cssText = 'display:flex;align-items:center;gap:4px';
@@ -1754,7 +1765,7 @@
       // sort payload), so paging/sorting never disturbs the other tiles.
       async function reload() {
         if (!currentParams) return;
-        const cap = el.querySelector('.jt-caption-text');
+        const cap = el.closest('.tile')?.querySelector('.jt-caption-text');
         if (cap) { cap.textContent = 'Loading'; cap.classList.add('jt-loading'); }
         el.querySelectorAll('.job-table-foot button, .job-table-foot input, .job-table-foot select')
           .forEach(c => { c.disabled = true; });
@@ -1776,12 +1787,22 @@
           if (!document.body.contains(el) || el.dataset.plotType !== 'jobtable') return;
           renderJobTable(id, { jobs: data });
         } catch (e) {
-          if (document.body.contains(el))
+          if (document.body.contains(el)) {
+            // Also clear the header slot, or it would keep a stale count (or
+            // a stuck animated "Loading") next to the error message.
+            const slot = el.closest('.tile')?.querySelector('.jt-head-slot');
+            if (slot) slot.innerHTML = '';
             el.innerHTML = `<div class="tile-error">Error: ${e.message}</div>`;
+          }
         }
       }
 
-      if (!total) { el.textContent = 'No jobs found.'; return; }
+      if (!total) {
+        const slot = el.closest('.tile')?.querySelector('.jt-head-slot');
+        if (slot) slot.innerHTML = '';
+        el.textContent = 'No jobs found.';
+        return;
+      }
 
       // The Unused columns depend on the efficiency metric picked at last Update.
       const metricName = (currentParams && currentParams.metric) || 'selected metric';
@@ -1866,8 +1887,12 @@
       const box = document.createElement('div');
       box.className = 'job-table-box';
 
-      const caption = document.createElement('div');
-      caption.className = 'job-table-caption';
+      // The caption content (jobs-count label + column picker) lives in the
+      // tile header's .jt-head-slot (created by renderLayout), not in a row of
+      // its own — one line saved for the table. Rebuilt on every render.
+      const caption = el.closest('.tile')?.querySelector('.jt-head-slot')
+        ?? document.createElement('span');   // detached fallback: renders nothing
+      caption.innerHTML = '';
       // Count text in its own span so reload() can swap it for the animated
       // "Loading" cue without wiping the column picker that shares this line.
       const capText = document.createElement('span');
@@ -2041,6 +2066,9 @@
       pageLink.textContent = page.toLocaleString('en-US');
       if (pages > 1) {
         pageLink.className = 'jt-page-link';
+        // Reserve the width of the largest page number (ch ≈ digit width;
+        // thousands separators counted, slightly over-wide for them).
+        pageLink.style.minWidth = `${pages.toLocaleString('en-US').length}ch`;
         pageLink.tabIndex = 0;
         pageLink.title = `Click to jump to a page (1–${pages.toLocaleString('en-US')})`;
         pageLink.addEventListener('click', openPop);
@@ -2050,11 +2078,8 @@
       }
       pageInfo.append('Page ', pageLink, ` / ${pages.toLocaleString('en-US')}`);
 
-      const spacer = document.createElement('span');
-      spacer.className = 'jt-spacer';
-
       const szLabel = document.createElement('label');
-      szLabel.textContent = 'Rows ';
+      szLabel.textContent = 'Jobs per page ';
       const sz = document.createElement('select');
       JOBTABLE_PAGE_SIZES.forEach(n => {
         const opt = document.createElement('option');
@@ -2073,9 +2098,9 @@
       });
       szLabel.appendChild(sz);
 
-      foot.append(first, prev, pageInfo, next, last, spacer, szLabel);
+      foot.append(first, prev, pageInfo, next, last, szLabel);
 
-      // ── Column-visibility picker (caption line, right-aligned) ────────────
+      // ── Column-visibility picker (header slot, after the jobs count) ──────
       // Pure display: toggling a checkbox shows/hides that column live (no
       // refetch) and the menu stays open. Mirrors the toolbar's cluster /
       // job-state dropdowns; the choice is global (jobTableHiddenCols).
@@ -2143,7 +2168,6 @@
       colMenu.append(colBtn, colPanel);
       caption.appendChild(colMenu);
 
-      box.appendChild(caption);
       box.appendChild(wrap);
       box.appendChild(foot);
       el.appendChild(box);

--- a/sarc/api/metrics.html
+++ b/sarc/api/metrics.html
@@ -1677,8 +1677,8 @@
           title: `RGU × elapsed time, shown in ${unit.label}`,
           fmt: fmtRguTime },
         { key: 'gpu_sm_occupancy_mean', label: 'SM occ',    fmt: v => v != null ? (v*100).toFixed(1)+'%' : '—' },
-        { key: 'waste',                 label: `${metricPretty} waste (${unit.label})`,
-          title: `RGU·time × (1 − mean ${metricPretty}): estimated unused RGU·time, taking the selected efficiency metric as the "useful" fraction`,
+        { key: 'waste',                 label: `Waste (${unit.label})`,
+          title: `RGU·time × (1 − mean ${metricPretty}): estimated unused RGU·time`,
           fmt: fmtRguTime },
         { key: 'gpu_type',              label: 'GPU type' },
         {% if is_admin %}

--- a/sarc/api/metrics.html
+++ b/sarc/api/metrics.html
@@ -1699,19 +1699,21 @@
         { key: 'rgu_hours',             label: unit.label,
           title: `RGU × elapsed time, shown in ${unit.label}`,
           fmt: fmtRguTime },
-
+        // Fixed RGU·h twin, skipped when the toolbar unit is already hours
+        // (it would be an exact duplicate).
+        ...(unit === unitHour ? [] : [
         { key: 'rgu_hours',             label: unitHour.label,
           title: `RGU × elapsed time, shown in ${unitHour.label}`,
           fmt: fmtRguHour },
-
+        ]),
         { key: 'waste',                 label: `Unused (${unit.label})`,
           title: `RGU·time × (1 − mean ${metricPretty}): estimated unused RGU·time`,
           fmt: fmtRguTime },
-
+        ...(unit === unitHour ? [] : [
         { key: 'waste',                 label: `Unused (${unitHour.label})`,
           title: `RGU·time × (1 − mean ${metricPretty}): estimated unused RGU·time`,
           fmt: fmtRguHour },
-
+        ]),
         { key: 'gpu_sm_occupancy_mean', label: 'SM occ',    fmt: v => v != null ? (v < 0 ? 'NaN' : (v*100).toFixed(1)+'%') : '—' },
         { key: 'gpu_utilization_mean',  label: 'GPU util',  fmt: v => v != null ? (v < 0 ? 'NaN' : (v*100).toFixed(1)+'%') : '—' },
         { key: 'gpu_type',              label: 'GPU type' },

--- a/sarc/api/metrics.html
+++ b/sarc/api/metrics.html
@@ -1115,6 +1115,10 @@
       const el = document.getElementById(id);
       if (!el || !d.rgu_usage.length) return;
       const unit = rguUnit();
+      // The wasted/unused hovers name the efficiency metric picked at last
+      // Update (non-admins are pinned to SM occupancy).
+      const metricName = (currentParams && currentParams.metric) || 'gpu_sm_occupancy';
+      const metricPretty = METRICS[metricName] || metricName;
 
       // Box/ctrl/plot layout (reusing the heatmap's classes) so a small "View:"
       // picker sits above the plot, which fills the rest at the tile's fixed height.
@@ -1151,14 +1155,14 @@
         Plotly.react(plot, [
           { type: 'bar', name: 'Used',   x: X, y: [usedTot * unit.factor], marker: { color: '#1a6fd4' },
             hovertemplate: unit.label + ' used: %{y:,.1f}<extra></extra>' },
-          { type: 'bar', name: `Wasted under ${MIN_USAGE_EXPECTED_PERCENT} %`, x: X, y: [wastedTot * unit.factor], marker: { color: '#ff0000' },
-            hovertemplate: `${unit.label} wasted under ${MIN_USAGE_EXPECTED_PERCENT} %: %{y:,.1f}<extra></extra>` },
-          { type: 'bar', name: `Unused over ${MIN_USAGE_EXPECTED_PERCENT} %`, x: X, y: [unusedTot * unit.factor], marker: { color: '#a8c8f0' },
-            hovertemplate: `${unit.label} unused over ${MIN_USAGE_EXPECTED_PERCENT} %: %{y:,.1f}<extra></extra>` },
+          { type: 'bar', name: `Wasted (below ${MIN_USAGE_EXPECTED_PERCENT} % min)`, x: X, y: [wastedTot * unit.factor], marker: { color: '#ff0000' },
+            hovertemplate: `${unit.label} wasted: %{y:,.1f}<br>shortfall of jobs below the <br>${MIN_USAGE_EXPECTED_PERCENT} % ${metricPretty} minimum<extra></extra>` },
+          { type: 'bar', name: 'Unused (above min)', x: X, y: [unusedTot * unit.factor], marker: { color: '#a8c8f0' },
+            hovertemplate: `${unit.label} unused: %{y:,.1f}<br>idle capacity above the ${MIN_USAGE_EXPECTED_PERCENT} % minimum<extra></extra>` },
           { type: 'bar', name: 'No metric data', x: X, y: [unmTot * unit.factor], marker: { color: '#bdbdbd' },
             hovertemplate: unit.label + ' (no metric): %{y:,.1f}<extra></extra>' },
         ], pLayout({
-          title: { text: 'Total ' + unit.label + ' — Whole range (Used vs Unused)', font: { size: 16 } },
+          title: { text: 'Total ' + unit.label + ' — Whole range (Used / Wasted / Unused)', font: { size: 16 } },
           barmode: 'stack', bargap: 0.7,
           xaxis: { type: 'category' },
           yaxis: { title: { text: 'Total ' + unit.label } },
@@ -1183,17 +1187,17 @@
         { type: 'bar', name: 'Used',   x: periods, y: rguUsed, customdata: periodEnds,
           marker: { color: colorUsed },
           hovertemplate: 'Period: %{x}<br>' + unit.label + ' used: %{y:,.1f}<extra></extra>' },
-        { type: 'bar', name: `Wasted under ${MIN_USAGE_EXPECTED_PERCENT} %`,   x: periods, y: rguWasted, customdata: periodEnds,
+        { type: 'bar', name: `Wasted (below ${MIN_USAGE_EXPECTED_PERCENT} % min)`,   x: periods, y: rguWasted, customdata: periodEnds,
           marker: { color: colorWasted },
-          hovertemplate: `Period: %{x}<br>${unit.label} wasted under ${MIN_USAGE_EXPECTED_PERCENT} %: %{y:,.1f}<extra></extra>` },
-        { type: 'bar', name: `Unused over ${MIN_USAGE_EXPECTED_PERCENT} %`, x: periods, y: rguUnused, customdata: periodEnds,
+          hovertemplate: `Period: %{x}<br>${unit.label} wasted: %{y:,.1f}<br>shortfall of jobs below the <br>${MIN_USAGE_EXPECTED_PERCENT} % ${metricPretty} minimum<extra></extra>` },
+        { type: 'bar', name: 'Unused (above min)', x: periods, y: rguUnused, customdata: periodEnds,
           marker: { color: colorUnused },
-          hovertemplate: `Period: %{x}<br>${unit.label} unused over ${MIN_USAGE_EXPECTED_PERCENT} %: %{y:,.1f}<extra></extra>` },
+          hovertemplate: `Period: %{x}<br>${unit.label} unused: %{y:,.1f}<br>idle capacity above the ${MIN_USAGE_EXPECTED_PERCENT} % minimum<extra></extra>` },
         { type: 'bar', name: 'No metric data', x: periods, y: rguUnmeasured, customdata: periodEnds,
           marker: { color: colorUnmeasured },
           hovertemplate: 'Period: %{x}<br>' + unit.label + ' (no metric): %{y:,.1f}<extra></extra>' },
       ], pLayout({
-        title: { text: 'Total ' + unit.label + ' per Period — Used vs Unused (click to focus)', font: { size: 16 } },
+        title: { text: 'Total ' + unit.label + ' per Period — Used / Wasted / Unused (click to focus)', font: { size: 16 } },
         barmode: 'stack',
         xaxis: { title: { text: 'Period start' }, type: 'category', tickangle: -45 },
         yaxis: { title: { text: 'Total ' + unit.label } },

--- a/sarc/api/metrics.html
+++ b/sarc/api/metrics.html
@@ -1710,7 +1710,6 @@
         { key: 'requested_gpu',         label: 'Requested GPU', fmt: fmtInt },
         { key: 'allocated_gpu',         label: 'Allocated GPU', fmt: fmtInt },
         {% if is_admin %}
-        { key: 'billing',               label: 'Billing',   fmt: fmtInt },
         { key: 'gpu_memory_max',        label: 'Mem max',   fmt: v => v != null ? (v*100).toFixed(1)+'%' : '—' },
         {% endif %}
         { key: 'nodes',                 label: 'Nodes',     cls: 'col-cmd' },

--- a/sarc/api/metrics.html
+++ b/sarc/api/metrics.html
@@ -356,6 +356,9 @@
   <div id="tile-grid"></div>
 
   <script>
+    // Minimum expected usage: sent to /rgu_usage as `min_usage` (threshold of
+    // the per-job wasted-RGU shortfall, computed server-side) and shown in the
+    // Wasted/Unused bar labels.
     const MIN_USAGE_EXPECTED_PERCENT = 15;
 
     const SEC_TO_H = 1 / 3600;
@@ -1108,10 +1111,6 @@
       });
     }
 
-    function _jobRguUnusedUnderThreshold(r) {
-      return Math.max(0, (MIN_USAGE_EXPECTED_PERCENT * (r.rgu_allocated - r.rgu_unmeasured) / 100 - r.rgu_used));
-    }
-
     function renderRguUsage(id, d) {
       const el = document.getElementById(id);
       if (!el || !d.rgu_usage.length) return;
@@ -1146,8 +1145,7 @@
         // purpose (no per-bucket axis) and the single bar is not click-to-focus.
         const sum = key => d.rgu_usage.reduce((a, r) => a + (r[key] || 0), 0);
         const reqTot = sum('rgu_allocated'), usedTot = sum('rgu_used'), unmTot = sum('rgu_unmeasured');
-        const bestUsedTot = (reqTot - unmTot) * MIN_USAGE_EXPECTED_PERCENT / 100;
-        const wastedTot = Math.max(0, bestUsedTot - usedTot);
+        const wastedTot = sum('rgu_wasted');
         const unusedTot = reqTot - usedTot - unmTot - wastedTot;
         const X = ['Whole range'];
         Plotly.react(plot, [
@@ -1174,8 +1172,8 @@
       const periods    = d.rgu_usage.map(r => r.period_start);
       const periodEnds = d.rgu_usage.map(r => r.period_end);
       const rguUsed       = d.rgu_usage.map(r => r.rgu_used * unit.factor);
-      const rguWasted     = d.rgu_usage.map(r => _jobRguUnusedUnderThreshold(r) * unit.factor);
-      const rguUnused     = d.rgu_usage.map(r => (r.rgu_allocated - r.rgu_used - r.rgu_unmeasured - _jobRguUnusedUnderThreshold(r)) * unit.factor);
+      const rguWasted     = d.rgu_usage.map(r => (r.rgu_wasted || 0) * unit.factor);
+      const rguUnused     = d.rgu_usage.map(r => (r.rgu_allocated - r.rgu_used - r.rgu_unmeasured - (r.rgu_wasted || 0)) * unit.factor);
       const rguUnmeasured = d.rgu_usage.map(r => (r.rgu_unmeasured || 0) * unit.factor);
       const colorUsed      = periods.map(p => { const f = periodInFocus(p); return f === null ? '#1a6fd4' : f ? '#e07020' : '#c8d8f0'; });
       const colorUnused    = periods.map(p => { const f = periodInFocus(p); return f === null ? '#a8c8f0' : f ? '#f0c090' : '#e4eef8'; });
@@ -2272,7 +2270,7 @@
       switch (ep) {
         case 'job_counts': return '/dash/metrics/job_counts?' + new URLSearchParams({ ...base, period: p.period });
         case 'heatmap':   return '/dash/metrics/job_times_vs_limit?' + new URLSearchParams({ ...base, ...focusParams });
-        case 'rgu_usage': return '/dash/metrics/rgu_usage?' + new URLSearchParams({ ...base, period: p.period, metric: p.metric });
+        case 'rgu_usage': return '/dash/metrics/rgu_usage?' + new URLSearchParams({ ...base, period: p.period, metric: p.metric, min_usage: MIN_USAGE_EXPECTED_PERCENT / 100 });
         case 'density':   return '/dash/metrics/metric_distribution?' + new URLSearchParams({ ...densityParams, ...focusParams });
         case 'jobs':      return jobsURL(p, JOBTABLE_DEFAULTS);
         {% if is_admin %}

--- a/sarc/api/metrics.html
+++ b/sarc/api/metrics.html
@@ -1851,7 +1851,7 @@
         th.textContent = c.label;
         if (c.title) {
           th.title = c.title;
-          if (c.adminOnly) th.title += " (admin column)";
+          if (c.adminOnly) th.title += " (admin-only column)";
         }
         if (c.adminOnly) th.classList.add('th-admin-only');
         if (!SORTABLE.has(c.key)) {

--- a/sarc/api/metrics.html
+++ b/sarc/api/metrics.html
@@ -166,6 +166,7 @@
     }
     .job-table th.no-sort { cursor: default; }
     .job-table th.no-sort:hover { background: #f0f0f0; }
+    .job-table th.th-admin-only { color: #bb0000; }
     /* Job-table pagination footer */
     .job-table-foot {
       flex-shrink: 0; display: flex; align-items: center; gap: 10px;
@@ -1682,7 +1683,7 @@
         { key: 'job_id',                label: 'Job ID',    fmt: fmtInt },
         { key: 'submit_time',           label: 'Submitted', fmt: fmtDateTime },
         {% if is_admin %}
-        { key: 'user',                  label: 'User' },
+        { key: 'user',                  label: 'User', adminOnly: true, title: 'Cluster user name' },
         {% endif %}
         { key: 'job_state',             label: 'State' },
         { key: 'elapsed',               label: 'Elapsed',   fmt: v => {
@@ -1700,17 +1701,17 @@
         { key: 'gpu_utilization_mean',  label: 'GPU util',  fmt: v => v != null ? (v < 0 ? 'NaN' : (v*100).toFixed(1)+'%') : '—' },
         { key: 'gpu_type',              label: 'GPU type' },
         {% if is_admin %}
-        { key: 'gpu_type_rgu',          label: 'GPU type RGU',
+        { key: 'gpu_type_rgu',          label: 'GPU type RGU', adminOnly: true,
           title: 'Per-GPU DRAC RGU weight of this GPU type',
           fmt: v => v != null ? v.toFixed(2) : '—' },
-        { key: 'rgu',                   label: 'RGU',
+        { key: 'rgu',                   label: 'RGU', adminOnly: true,
           title: 'RGU weight of the job\'s allocated GPUs',
           fmt: v => v != null ? v.toFixed(2) : '—' },
         {% endif %}
         { key: 'requested_gpu',         label: 'Requested GPU', fmt: fmtInt },
         { key: 'allocated_gpu',         label: 'Allocated GPU', fmt: fmtInt },
         {% if is_admin %}
-        { key: 'gpu_memory_max',        label: 'Mem max',   fmt: v => v != null ? (v*100).toFixed(1)+'%' : '—' },
+        { key: 'gpu_memory_max',        label: 'Mem max',   fmt: v => v != null ? (v*100).toFixed(1)+'%' : '—', adminOnly: true, title: 'Max memory usage' },
         {% endif %}
         { key: 'nodes',                 label: 'Nodes',     cls: 'col-cmd' },
       ];
@@ -1748,11 +1749,15 @@
         const th = document.createElement('th');
         th.dataset.col = c.key;
         th.textContent = c.label;
-        if (c.title) th.title = c.title;
+        if (c.title) {
+          th.title = c.title;
+          if (c.adminOnly) th.title += " (admin column)";
+        }
+        if (c.adminOnly) th.classList.add('th-admin-only');
         if (!SORTABLE.has(c.key)) {
-          th.className = 'no-sort';
+          th.classList.add('no-sort');
         } else {
-          if (c.key === sortKey) th.className = sortDir === 1 ? 'sort-asc' : 'sort-desc';
+          if (c.key === sortKey) th.classList.add( sortDir === 1 ? 'sort-asc' : 'sort-desc' );
           // A new sort order spans every page, so reset to the first page and
           // re-fetch (the server does the ordering).
           th.addEventListener('click', () => {

--- a/sarc/api/metrics.html
+++ b/sarc/api/metrics.html
@@ -117,11 +117,26 @@
     .add-row-label { font-size: 13px; color: #888; }
 
     /* Metric heatmap: per-tile secondary-metric picker sitting above the plot. */
-    .ms-box  { display: flex; flex-direction: column; width: 100%; height: 100%; }
+    .ms-box  { position: relative; display: flex; flex-direction: column; width: 100%; height: 100%; }
     .ms-ctrl { flex-shrink: 0; font-size: 12px; color: #888; padding: 2px 0 6px;
                display: flex; align-items: center; gap: 6px; }
     .ms-plot { width: 100%; flex: 1; min-height: 0; }
     .ms-metric2 { font-size: 12px; padding: 1px 6px; max-width: 160px; }
+    /* RGU-usage: the "View:" picker shares its row with the plot title (an HTML
+       title — the plot carries no Plotly title) to save one line of tile
+       height. Grid centres the title on the tile; the picker sits on the left.
+       Font stack/colour mirror Plotly's default titles next door. */
+    /* RGU-usage: the "View:" picker floats over the plot's top-left corner —
+       the empty left side of the title band (the modebar hovers top-RIGHT).
+       The plot then keeps the exact same Plotly layout as rgu_by_cluster, so
+       the two tiles align by construction, with no height arithmetic. */
+    .ms-float-ctrl {
+      position: absolute; top: 0; left: 0; z-index: 10;
+      font-size: 12px; color: #888; display: flex; align-items: center; gap: 6px;
+      padding: 2px 4px 4px 0;
+      background-color: white;
+    }
+    .ms-float-ctrl .add-select { padding: 1px 6px; font-size: 11px; }
     /* "?" help badge in the RGU-usage tile header: standard circular help
        button (quiet grey, blue on hover — same hover palette as .add-tile-btn);
        clicking it opens a definition panel that expands rightward from the
@@ -717,6 +732,16 @@
       }));
     }
 
+    // Plotly's own responsive handler resizes the plots live but can leave a
+    // wrapping horizontal legend at its old position (drawn over the bars)
+    // when the window grows back. Once the resize settles, re-render the RGU
+    // tiles from cache: a full react recomputes margins and legend placement.
+    let _resizeTimer = null;
+    window.addEventListener('resize', () => {
+      clearTimeout(_resizeTimer);
+      _resizeTimer = setTimeout(rerenderRguTiles, 250);
+    });
+
     // Pressing Enter in any filter field applies the filters, like clicking Update.
     // Buttons keep their own behaviour (Update / Reset, dropdown toggles, All/None).
     document.querySelector('.controls').addEventListener('keydown', e => {
@@ -1211,11 +1236,12 @@
       const metricName = (currentParams && currentParams.metric) || 'gpu_sm_occupancy';
       const metricPretty = METRICS[metricName] || metricName;
 
-      // Box/ctrl/plot layout (reusing the heatmap's classes) so a small "View:"
-      // picker sits above the plot, which fills the rest at the tile's fixed height.
+      // Box/plot layout (reusing the heatmap's classes); the "View:" picker
+      // floats over the plot's top-left corner (see .ms-float-ctrl), so the
+      // plot itself is laid out exactly like rgu_by_cluster next door.
       el.innerHTML = '';
       const box = document.createElement('div'); box.className = 'ms-box';
-      const ctrl = document.createElement('div'); ctrl.className = 'ms-ctrl';
+      const ctrl = document.createElement('div'); ctrl.className = 'ms-float-ctrl';
       const lab = document.createElement('label');
       lab.textContent = 'View: ';
       const sel = document.createElement('select');
@@ -1253,12 +1279,15 @@
           { type: 'bar', name: 'No metric data', x: X, y: [unmTot * unit.factor], marker: { color: '#bdbdbd' },
             hovertemplate: unit.label + ' (no metric): %{y:,.1f}<extra></extra>' },
         ], pLayout({
-          title: { text: 'Total ' + unit.label + ' — Whole range (Used / Wasted / Unused)', font: { size: 16 } },
+          // Same pinned title + t as rgu_by_cluster, so the two tiles align
+          // by construction (the View picker floats over the top-left corner).
+          title: { text: 'Total ' + unit.label + ' — Whole range (Used / Wasted / Unused)',
+                   font: { size: 16 }, y: 1, yanchor: 'top', pad: { t: 2 } },
           barmode: 'stack', bargap: 0.7,
           xaxis: { type: 'category' },
           yaxis: { title: { text: 'Total ' + unit.label } },
           legend: { orientation: 'h', x: 0, xanchor: 'left', y: 1.02, yanchor: 'bottom' },
-          margin: { l: 60, r: 20, t: 72, b: 60 },
+          margin: { l: 60, r: 20, t: 58, b: 60 },
         }), { responsive: true });
         return;
       }
@@ -1288,12 +1317,13 @@
           marker: { color: colorUnmeasured },
           hovertemplate: 'Period: %{x}<br>' + unit.label + ' (no metric): %{y:,.1f}<extra></extra>' },
       ], pLayout({
-        title: { text: 'Total ' + unit.label + ' per Period — Used / Wasted / Unused (click to focus)', font: { size: 16 } },
+        title: { text: 'Total ' + unit.label + ' per Period — Used / Wasted / Unused (click to focus)',
+                 font: { size: 16 }, y: 1, yanchor: 'top', pad: { t: 2 } },
         barmode: 'stack',
         xaxis: { title: { text: 'Period start' }, type: 'category', tickangle: -45 },
         yaxis: { title: { text: 'Total ' + unit.label } },
         legend: { orientation: 'h', x: 0, xanchor: 'left', y: 1.02, yanchor: 'bottom' },
-        margin: { l: 60, r: 20, t: 72, b: 100 },
+        margin: { l: 60, r: 20, t: 58, b: 100 },
       }), { responsive: true }).then(gd => {
         gd.removeAllListeners('plotly_click');
         gd.on('plotly_click', evt => {
@@ -1344,7 +1374,11 @@
         hovertemplate: s.cluster + '<br>Period: %{x}<br>' + unit.label + ': %{customdata[1]:,.2f}<extra></extra>',
       })).sort((a, b) => a.name.localeCompare(b.name));
       Plotly.react(id, traces, pLayout({
-        title: { text: 'Total ' + unit.label + ' by Cluster (click to focus)', font: { size: 16 } },
+        // Title pinned to the container top; t:58 = title band + legend +
+        // gap. rgu_usage uses the same pinned title + t, so titles, legends
+        // and bars align side by side.
+        title: { text: 'Total ' + unit.label + ' by Cluster (click to focus)',
+                 font: { size: 16 }, y: 1, yanchor: 'top', pad: { t: 2 } },
         // Manual per-period `base` offsets do the stacking, so overlay — not
         // 'stack', which ignores base and re-stacks in (global) trace order.
         barmode: 'overlay',
@@ -1356,7 +1390,7 @@
         // there is only one trace).
         showlegend: true,
         legend: { orientation: 'h', x: 0, xanchor: 'left', y: 1.02, yanchor: 'bottom', traceorder: 'normal' },
-        margin: { l: 60, r: 20, t: 72, b: 100 },
+        margin: { l: 60, r: 20, t: 58, b: 100 },
       }), { responsive: true }).then(gd => {
         gd.removeAllListeners('plotly_click');
         gd.on('plotly_click', evt => {

--- a/sarc/api/metrics.html
+++ b/sarc/api/metrics.html
@@ -341,7 +341,7 @@
     {% if is_admin %}
     <div class="ctrl">
       <label for="metric-select">Efficiency metric</label>
-      <select id="metric-select" title="Metric taken as the 'useful' fraction: it splits Used vs Unused RGU (RGU usage, RGU by user, job-table waste column) and is the value plotted in Metric Trend, Density and the heatmap. Takes effect on Update."></select>
+      <select id="metric-select" title="Metric taken as the 'useful' fraction: it splits Used vs Unused RGU (RGU usage, RGU by user, job-table Unused columns) and is the value plotted in Metric Trend, Density and the heatmap. Takes effect on Update."></select>
     </div>
     {% endif %}
     <button onclick="loadCharts()" title="Apply the current filters (date range, clusters, {% if is_admin %}user, {% endif %}job states, metric) and reload every plot.">Update</button>
@@ -357,7 +357,6 @@
 
   <script>
     const MIN_USAGE_EXPECTED_PERCENT = 15;
-    const MIN_USAGE_EXPECTED = MIN_USAGE_EXPECTED_PERCENT / 100;
 
     const SEC_TO_H = 1 / 3600;
 
@@ -1109,7 +1108,7 @@
       });
     }
 
-    function _jobRguWasted(r) {
+    function _jobRguUnusedUnderThreshold(r) {
       return Math.max(0, (MIN_USAGE_EXPECTED_PERCENT * (r.rgu_allocated - r.rgu_unmeasured) / 100 - r.rgu_used));
     }
 
@@ -1154,10 +1153,10 @@
         Plotly.react(plot, [
           { type: 'bar', name: 'Used',   x: X, y: [usedTot * unit.factor], marker: { color: '#1a6fd4' },
             hovertemplate: unit.label + ' used: %{y:,.1f}<extra></extra>' },
-          { type: 'bar', name: 'Wasted', x: X, y: [wastedTot * unit.factor], marker: { color: '#ff0000' },
-            hovertemplate: unit.label + ' wasted: %{y:,.1f}<extra></extra>' },
-          { type: 'bar', name: 'Unused', x: X, y: [unusedTot * unit.factor], marker: { color: '#a8c8f0' },
-            hovertemplate: unit.label + ' unused: %{y:,.1f}<extra></extra>' },
+          { type: 'bar', name: `Wasted under ${MIN_USAGE_EXPECTED_PERCENT} %`, x: X, y: [wastedTot * unit.factor], marker: { color: '#ff0000' },
+            hovertemplate: `${unit.label} wasted under ${MIN_USAGE_EXPECTED_PERCENT} %: %{y:,.1f}<extra></extra>` },
+          { type: 'bar', name: `Unused over ${MIN_USAGE_EXPECTED_PERCENT} %`, x: X, y: [unusedTot * unit.factor], marker: { color: '#a8c8f0' },
+            hovertemplate: `${unit.label} unused over ${MIN_USAGE_EXPECTED_PERCENT} %: %{y:,.1f}<extra></extra>` },
           { type: 'bar', name: 'No metric data', x: X, y: [unmTot * unit.factor], marker: { color: '#bdbdbd' },
             hovertemplate: unit.label + ' (no metric): %{y:,.1f}<extra></extra>' },
         ], pLayout({
@@ -1175,8 +1174,8 @@
       const periods    = d.rgu_usage.map(r => r.period_start);
       const periodEnds = d.rgu_usage.map(r => r.period_end);
       const rguUsed       = d.rgu_usage.map(r => r.rgu_used * unit.factor);
-      const rguWasted     = d.rgu_usage.map(r => _jobRguWasted(r) * unit.factor);
-      const rguUnused     = d.rgu_usage.map(r => (r.rgu_allocated - r.rgu_used - r.rgu_unmeasured - _jobRguWasted(r)) * unit.factor);
+      const rguWasted     = d.rgu_usage.map(r => _jobRguUnusedUnderThreshold(r) * unit.factor);
+      const rguUnused     = d.rgu_usage.map(r => (r.rgu_allocated - r.rgu_used - r.rgu_unmeasured - _jobRguUnusedUnderThreshold(r)) * unit.factor);
       const rguUnmeasured = d.rgu_usage.map(r => (r.rgu_unmeasured || 0) * unit.factor);
       const colorUsed      = periods.map(p => { const f = periodInFocus(p); return f === null ? '#1a6fd4' : f ? '#e07020' : '#c8d8f0'; });
       const colorUnused    = periods.map(p => { const f = periodInFocus(p); return f === null ? '#a8c8f0' : f ? '#f0c090' : '#e4eef8'; });
@@ -1186,12 +1185,12 @@
         { type: 'bar', name: 'Used',   x: periods, y: rguUsed, customdata: periodEnds,
           marker: { color: colorUsed },
           hovertemplate: 'Period: %{x}<br>' + unit.label + ' used: %{y:,.1f}<extra></extra>' },
-        { type: 'bar', name: 'Wasted',   x: periods, y: rguWasted, customdata: periodEnds,
+        { type: 'bar', name: `Wasted under ${MIN_USAGE_EXPECTED_PERCENT} %`,   x: periods, y: rguWasted, customdata: periodEnds,
           marker: { color: colorWasted },
-          hovertemplate: 'Period: %{x}<br>' + unit.label + ' wasted: %{y:,.1f}<extra></extra>' },
-        { type: 'bar', name: 'Unused', x: periods, y: rguUnused, customdata: periodEnds,
+          hovertemplate: `Period: %{x}<br>${unit.label} wasted under ${MIN_USAGE_EXPECTED_PERCENT} %: %{y:,.1f}<extra></extra>` },
+        { type: 'bar', name: `Unused over ${MIN_USAGE_EXPECTED_PERCENT} %`, x: periods, y: rguUnused, customdata: periodEnds,
           marker: { color: colorUnused },
-          hovertemplate: 'Period: %{x}<br>' + unit.label + ' unused: %{y:,.1f}<extra></extra>' },
+          hovertemplate: `Period: %{x}<br>${unit.label} unused over ${MIN_USAGE_EXPECTED_PERCENT} %: %{y:,.1f}<extra></extra>` },
         { type: 'bar', name: 'No metric data', x: periods, y: rguUnmeasured, customdata: periodEnds,
           marker: { color: colorUnmeasured },
           hovertemplate: 'Period: %{x}<br>' + unit.label + ' (no metric): %{y:,.1f}<extra></extra>' },
@@ -1657,7 +1656,7 @@
 
       if (!total) { el.textContent = 'No jobs found.'; return; }
 
-      // The Waste column depends on the efficiency metric picked at last Update.
+      // The Unused columns depend on the efficiency metric picked at last Update.
       const metricName = (currentParams && currentParams.metric) || 'selected metric';
       const metricPretty = METRICS[metricName] || metricName;
       // RGU·time columns honour the toolbar unit (display rescale of the RGU·h
@@ -1705,11 +1704,11 @@
           title: `RGU × elapsed time, shown in ${unitHour.label}`,
           fmt: fmtRguHour },
 
-        { key: 'waste',                 label: `Waste (${unit.label})`,
+        { key: 'waste',                 label: `Unused (${unit.label})`,
           title: `RGU·time × (1 − mean ${metricPretty}): estimated unused RGU·time`,
           fmt: fmtRguTime },
 
-        { key: 'waste',                 label: `Waste (${unitHour.label})`,
+        { key: 'waste',                 label: `Unused (${unitHour.label})`,
           title: `RGU·time × (1 − mean ${metricPretty}): estimated unused RGU·time`,
           fmt: fmtRguHour },
 

--- a/sarc/api/metrics.html
+++ b/sarc/api/metrics.html
@@ -355,6 +355,9 @@
   <div id="tile-grid"></div>
 
   <script>
+    const MIN_USAGE_EXPECTED_PERCENT = 15;
+    const MIN_USAGE_EXPECTED = MIN_USAGE_EXPECTED_PERCENT / 100;
+
     const SEC_TO_H = 1 / 3600;
 
     function isoDate(d) { return d.toISOString().split('T')[0]; }
@@ -1105,6 +1108,10 @@
       });
     }
 
+    function _jobRguWasted(r) {
+      return Math.max(0, (MIN_USAGE_EXPECTED_PERCENT * (r.rgu_allocated - r.rgu_unmeasured) / 100 - r.rgu_used));
+    }
+
     function renderRguUsage(id, d) {
       const el = document.getElementById(id);
       if (!el || !d.rgu_usage.length) return;
@@ -1138,12 +1145,17 @@
         // One stacked bar summing the whole Start–End range. Focus is ignored on
         // purpose (no per-bucket axis) and the single bar is not click-to-focus.
         const sum = key => d.rgu_usage.reduce((a, r) => a + (r[key] || 0), 0);
-        const reqTot = sum('rgu_requested'), usedTot = sum('rgu_used'), unmTot = sum('rgu_unmeasured');
+        const reqTot = sum('rgu_allocated'), usedTot = sum('rgu_used'), unmTot = sum('rgu_unmeasured');
+        const bestUsedTot = (reqTot - unmTot) * MIN_USAGE_EXPECTED_PERCENT / 100;
+        const wastedTot = Math.max(0, bestUsedTot - usedTot);
+        const unusedTot = reqTot - usedTot - unmTot - wastedTot;
         const X = ['Whole range'];
         Plotly.react(plot, [
           { type: 'bar', name: 'Used',   x: X, y: [usedTot * unit.factor], marker: { color: '#1a6fd4' },
             hovertemplate: unit.label + ' used: %{y:,.1f}<extra></extra>' },
-          { type: 'bar', name: 'Unused', x: X, y: [(reqTot - usedTot - unmTot) * unit.factor], marker: { color: '#a8c8f0' },
+          { type: 'bar', name: 'Wasted', x: X, y: [wastedTot * unit.factor], marker: { color: '#ff0000' },
+            hovertemplate: unit.label + ' wasted: %{y:,.1f}<extra></extra>' },
+          { type: 'bar', name: 'Unused', x: X, y: [unusedTot * unit.factor], marker: { color: '#a8c8f0' },
             hovertemplate: unit.label + ' unused: %{y:,.1f}<extra></extra>' },
           { type: 'bar', name: 'No metric data', x: X, y: [unmTot * unit.factor], marker: { color: '#bdbdbd' },
             hovertemplate: unit.label + ' (no metric): %{y:,.1f}<extra></extra>' },
@@ -1162,15 +1174,20 @@
       const periods    = d.rgu_usage.map(r => r.period_start);
       const periodEnds = d.rgu_usage.map(r => r.period_end);
       const rguUsed       = d.rgu_usage.map(r => r.rgu_used * unit.factor);
-      const rguUnused     = d.rgu_usage.map(r => (r.rgu_requested - r.rgu_used - (r.rgu_unmeasured || 0)) * unit.factor);
+      const rguWasted     = d.rgu_usage.map(r => _jobRguWasted(r) * unit.factor);
+      const rguUnused     = d.rgu_usage.map(r => (r.rgu_allocated - r.rgu_used - r.rgu_unmeasured - _jobRguWasted(r)) * unit.factor);
       const rguUnmeasured = d.rgu_usage.map(r => (r.rgu_unmeasured || 0) * unit.factor);
       const colorUsed      = periods.map(p => { const f = periodInFocus(p); return f === null ? '#1a6fd4' : f ? '#e07020' : '#c8d8f0'; });
       const colorUnused    = periods.map(p => { const f = periodInFocus(p); return f === null ? '#a8c8f0' : f ? '#f0c090' : '#e4eef8'; });
+      const colorWasted    = periods.map(p => { const f = periodInFocus(p); return f === null ? '#ff0000' : f ? '#aa00cc' : '#ffdddd'; });
       const colorUnmeasured= periods.map(p => { const f = periodInFocus(p); return f === null ? '#bdbdbd' : f ? '#8a8a8a' : '#e6e6e6'; });
       Plotly.react(plot, [
         { type: 'bar', name: 'Used',   x: periods, y: rguUsed, customdata: periodEnds,
           marker: { color: colorUsed },
           hovertemplate: 'Period: %{x}<br>' + unit.label + ' used: %{y:,.1f}<extra></extra>' },
+        { type: 'bar', name: 'Wasted',   x: periods, y: rguWasted, customdata: periodEnds,
+          marker: { color: colorWasted },
+          hovertemplate: 'Period: %{x}<br>' + unit.label + ' wasted: %{y:,.1f}<extra></extra>' },
         { type: 'bar', name: 'Unused', x: periods, y: rguUnused, customdata: periodEnds,
           marker: { color: colorUnused },
           hovertemplate: 'Period: %{x}<br>' + unit.label + ' unused: %{y:,.1f}<extra></extra>' },

--- a/sarc/api/metrics.html
+++ b/sarc/api/metrics.html
@@ -9,7 +9,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <title>Global Job Metrics ({{ user_email }})</title>
+  <title>Utilization Dashboard ({{ user_email }})</title>
   <script src="https://cdn.plot.ly/plotly-3.6.0.min.js"
           integrity="sha384-VJGrWzhaqeZH5V40n11N6iTMH+MBDakZZjfPZAPtqS/BCEnF102uwlswiJq07HmW"
           crossorigin="anonymous"></script>
@@ -253,7 +253,7 @@
 </head>
 <body>
   <h3>
-    Global Job Metrics
+    Utilization Dashboard
     <span class="conn-email {{ 'admin' if admin_email else 'user' }}">({{ user_email }})</span>
     {% if admin_email and view_as_email %}
     <span class="view-as-badge">/ as user <strong>{{ view_as_email }}</strong>

--- a/sarc/api/metrics.html
+++ b/sarc/api/metrics.html
@@ -542,7 +542,7 @@
 
     const PLOT_NAMES = {
       job_counts:      'Submitted jobs per period',
-      rgu_usage:       'RGU requested vs used',
+      rgu_usage:       'RGU allocated vs used',
       clusterrgu:      'RGU by cluster',
       jobtable:        'Job table',
       {% if is_admin %}

--- a/sarc/api/metrics.html
+++ b/sarc/api/metrics.html
@@ -811,7 +811,7 @@
     // RGU req-vs-used + RGU-by-cluster on row 1, job table on row 2. Copied per
     // call so mutating tileLayout never corrupts this template.
     {% if is_admin %}
-    const DEFAULT_LAYOUT = [['clusterrgu', 'jobtable'], ['metrictrend', 'userrgu']];
+    const DEFAULT_LAYOUT = [['rgu_usage', 'clusterrgu'], ['jobtable'], ['metrictrend', 'userrgu']];
     {% else %}
     const DEFAULT_LAYOUT = [['rgu_usage', 'clusterrgu'], ['jobtable']];
     {% endif %}

--- a/sarc/api/metrics.html
+++ b/sarc/api/metrics.html
@@ -1679,8 +1679,8 @@
         { key: 'waste',                 label: `Waste (${unit.label})`,
           title: `RGU·time × (1 − mean ${metricPretty}): estimated unused RGU·time`,
           fmt: fmtRguTime },
-        { key: 'gpu_sm_occupancy_mean', label: 'SM occ',    fmt: v => v != null ? (v*100).toFixed(1)+'%' : '—' },
-        { key: 'gpu_utilization_mean',  label: 'GPU util',  fmt: v => v != null ? (v*100).toFixed(1)+'%' : '—' },
+        { key: 'gpu_sm_occupancy_mean', label: 'SM occ',    fmt: v => v != null ? (v < 0 ? 'NaN' : (v*100).toFixed(1)+'%') : '—' },
+        { key: 'gpu_utilization_mean',  label: 'GPU util',  fmt: v => v != null ? (v < 0 ? 'NaN' : (v*100).toFixed(1)+'%') : '—' },
         { key: 'gpu_type',              label: 'GPU type' },
         {% if is_admin %}
         { key: 'gpu_type_rgu',          label: 'GPU type RGU',

--- a/sarc/api/metrics.html
+++ b/sarc/api/metrics.html
@@ -283,7 +283,7 @@
     <div class="ctrl">
       <label for="end">End</label>
       <input type="date" id="end"
-             title="End of the date range (inclusive), in UTC. Every plot and the job table cover jobs in this range. Takes effect on Update." />
+             title="End of the date range (exclusive: covers jobs submitted before this date), in UTC. Every plot and the job table cover jobs in this range. Takes effect on Update." />
     </div>
     <div class="ctrl">
       <label>Period</label>

--- a/sarc/api/metrics.html
+++ b/sarc/api/metrics.html
@@ -122,6 +122,28 @@
                display: flex; align-items: center; gap: 6px; }
     .ms-plot { width: 100%; flex: 1; min-height: 0; }
     .ms-metric2 { font-size: 12px; padding: 1px 6px; max-width: 160px; }
+    /* "?" help badge in the RGU-usage tile header: standard circular help
+       button (quiet grey, blue on hover — same hover palette as .add-tile-btn);
+       clicking it opens a definition panel that expands rightward from the
+       title (left-anchored, so it stays inside the tile). The title span goes
+       inline-flex so the badge is vertically centred on the text (a plain
+       vertical-align sits a 17px badge too low beside 13px text). */
+    .tile-title-help { display: inline-flex; align-items: center; gap: 6px; }
+    .ms-help-btn {
+      width: 17px; height: 17px; border-radius: 50%; box-sizing: border-box;
+      border: 1.5px solid #999; background: none; color: #999;
+      font-size: 11px; font-weight: 700; line-height: 1; padding: 0;
+      cursor: pointer; display: inline-flex; align-items: center; justify-content: center;
+    }
+    .ms-help-btn:hover { border-color: #1a6fd4; color: #1a6fd4; background: #dde6f5; }
+    .ms-help-panel {
+      position: absolute; left: 0; z-index: 9999; background: #fff;
+      border: 1px solid #ccc; border-radius: 4px;
+      box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+      width: 300px; padding: 8px 12px; font-size: 12px; color: #333;
+      font-weight: 400; text-align: left;
+    }
+    .ms-help-panel p { margin: 4px 0; }
 
     {% if is_admin %}
     /* RGU-by-user: per-tile "top N" + sort controls above the (dynamic-height) plot. */
@@ -360,6 +382,10 @@
     // the per-job wasted-RGU shortfall, computed server-side) and shown in the
     // Wasted/Unused bar labels.
     const MIN_USAGE_EXPECTED_PERCENT = 15;
+
+    // Temporary user-guide target (Google Doc), linked from inside the "ⓘ"
+    // help panel on the RGU-usage tiles.
+    const USER_GUIDE_URL = 'https://docs.google.com/document/d/1kLm-3JXlyuukIS0n2cR_8XxhQuKIvW7-omll-wwXvaM/';
 
     const SEC_TO_H = 1 / 3600;
 
@@ -887,6 +913,57 @@
       return sel;
     }
 
+    // "?" help badge for the RGU-usage tile title: click opens a panel defining
+    // Wasted/Unused with the user-guide link inside (a native title can't hold
+    // a clickable link). Open/close mechanics mirror the job-table column
+    // picker. The panel content is built on open so the metric name tracks the
+    // last Update — the tile header outlives chart re-renders.
+    function makeRguUsageHelp() {
+      const wrap = document.createElement('div');
+      wrap.className = 'js-dropdown';
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'ms-help-btn';
+      btn.textContent = '?';
+      btn.setAttribute('aria-label', 'Help: what do Wasted / Unused mean?');
+      const panel = document.createElement('div');
+      panel.className = 'ms-help-panel';
+      panel.style.display = 'none';
+      let closeTimer = null;
+      function openHelp() {
+        if (panel.style.display !== 'none') return;
+        const metricName = (currentParams && currentParams.metric) || 'gpu_sm_occupancy';
+        const metricPretty = METRICS[metricName] || metricName;
+        panel.innerHTML =
+          `<h3>What do Wasted / Unused mean?</h3>` +
+          `<p><strong>Wasted</strong> (red): unused compute missing for each job to reach the expected minimum of ` +
+          `${MIN_USAGE_EXPECTED_PERCENT} % ${metricPretty}.</p>` +
+          `<p><strong>Unused</strong> (light blue): idle capacity above the minimum.</p>` +
+          `<p><a href="${USER_GUIDE_URL}" target="_blank" rel="noopener">Open the user guide ↗</a></p>`;
+        panel.style.display = 'block';
+        // Defer so an opening click isn't caught as an outside click.
+        setTimeout(() => document.addEventListener('mousedown', onDown, true), 0);
+      }
+      function closeHelp() {
+        panel.style.display = 'none';
+        document.removeEventListener('mousedown', onDown, true);
+      }
+      function onDown(e) {
+        if (!panel.contains(e.target) && e.target !== btn) closeHelp();
+      }
+      // Hover opens; leaving closes after a short grace period so the pointer
+      // can travel into the panel (a child of `wrap`, so moving onto it never
+      // fires wrap's mouseleave). Click still toggles: keyboard/touch fallback.
+      wrap.addEventListener('mouseenter', () => { clearTimeout(closeTimer); openHelp(); });
+      wrap.addEventListener('mouseleave', () => { closeTimer = setTimeout(closeHelp, 250); });
+      btn.addEventListener('click', e => {
+        e.stopPropagation();
+        if (panel.style.display === 'none') openHelp(); else closeHelp();
+      });
+      wrap.append(btn, panel);
+      return wrap;
+    }
+
     function renderLayout() {
       const grid = document.getElementById('tile-grid');
       grid.innerHTML = '';
@@ -903,6 +980,10 @@
           header.className = 'tile-header';
           const title = document.createElement('span');
           title.textContent = PLOT_NAMES[plotType];
+          if (plotType === 'rgu_usage') {
+            title.classList.add('tile-title-help');
+            title.appendChild(makeRguUsageHelp());
+          }
           header.appendChild(title);
           {% if is_admin %}
           const actions = document.createElement('span');

--- a/sarc/api/metrics.html
+++ b/sarc/api/metrics.html
@@ -211,7 +211,7 @@
     }
     .job-table th.no-sort { cursor: default; }
     .job-table th.no-sort:hover { background: #f0f0f0; }
-    .job-table th.th-admin-only { color: #bb0000; }
+    .job-table th.th-admin-only { color: #bb00bb; }
     /* Job-table pagination footer */
     .job-table-foot {
       flex-shrink: 0; display: flex; align-items: center; gap: 10px;
@@ -1864,6 +1864,7 @@
         ]),
         { key: 'gpu_sm_occupancy_mean', label: 'SM occ',    fmt: v => v != null ? (v < 0 ? 'NaN' : (v*100).toFixed(1)+'%') : '—' },
         { key: 'gpu_utilization_mean',  label: 'GPU util',  fmt: v => v != null ? (v < 0 ? 'NaN' : (v*100).toFixed(1)+'%') : '—' },
+        { key: 'gpu_memory_max',        label: 'Mem max',   fmt: v => v != null ? (v*100).toFixed(1)+'%' : '—', title: 'Max memory usage' },
         { key: 'gpu_type',              label: 'GPU type' },
         {% if is_admin %}
         { key: 'gpu_type_rgu',          label: 'GPU type RGU', adminOnly: true,
@@ -1875,9 +1876,6 @@
         {% endif %}
         { key: 'requested_gpu',         label: 'Requested GPU', fmt: fmtInt },
         { key: 'allocated_gpu',         label: 'Allocated GPU', fmt: fmtInt },
-        {% if is_admin %}
-        { key: 'gpu_memory_max',        label: 'Mem max',   fmt: v => v != null ? (v*100).toFixed(1)+'%' : '—', adminOnly: true, title: 'Max memory usage' },
-        {% endif %}
         { key: 'nodes',                 label: 'Nodes',     cls: 'col-cmd' },
       ];
       // Columns the server can sort on; the array-valued 'nodes' column can't.

--- a/sarc/api/metrics.py
+++ b/sarc/api/metrics.py
@@ -249,8 +249,10 @@ def _apply_focus(
     return begin_dt, finish_dt
 
 
-def _nan_to_none(v: float | None) -> float | None:
-    return None if (isinstance(v, float) and math.isnan(v)) else v
+def _nan_to_none(
+    v: float | None, replace_with: float | int | None = None
+) -> float | None:
+    return replace_with if (isinstance(v, float) and math.isnan(v)) else v
 
 
 def _resolve_cluster_ids(sess: Session, clusters: list[str]) -> list[int] | None:
@@ -1332,8 +1334,12 @@ def metrics_jobs(
                 "rgu": round(float(row.rgu), 2),
                 "rgu_hours": round(rh, 2) if rh is not None else None,
                 "waste": waste,
-                "gpu_utilization_mean": _nan_to_none(row.gpu_utilization_mean),
-                "gpu_sm_occupancy_mean": _nan_to_none(row.gpu_sm_occupancy_mean),
+                "gpu_utilization_mean": _nan_to_none(
+                    row.gpu_utilization_mean, replace_with=-1
+                ),
+                "gpu_sm_occupancy_mean": _nan_to_none(
+                    row.gpu_sm_occupancy_mean, replace_with=-1
+                ),
                 "gpu_memory_max": _nan_to_none(row.gpu_memory_max),
             }
         )

--- a/sarc/api/metrics.py
+++ b/sarc/api/metrics.py
@@ -228,9 +228,7 @@ def _date_range(start, end) -> tuple[datetime, datetime]:
     begin = min(start, end)
     finish = max(start, end)
     begin_dt = datetime(begin.year, begin.month, begin.day, tzinfo=UTC)
-    finish_dt = datetime(finish.year, finish.month, finish.day, tzinfo=UTC) + timedelta(
-        days=1
-    )
+    finish_dt = datetime(finish.year, finish.month, finish.day, tzinfo=UTC)
     return begin_dt, finish_dt
 
 

--- a/sarc/api/metrics.py
+++ b/sarc/api/metrics.py
@@ -828,7 +828,7 @@ def metrics_rgu_usage(
             func.sum(rgu_used_term).label("rgu_used"),
             func.sum(rgu_unmeasured_term).label("rgu_unmeasured"),
             func.sum(rgu_wasted_term).label("rgu_wasted"),
-        ),
+        ),  # ty:ignore[no-matching-overload]
         sess,
         clusters,
         cluster_user,

--- a/sarc/api/metrics.py
+++ b/sarc/api/metrics.py
@@ -99,7 +99,7 @@ UTC = timezone.utc
 _DEFAULT_WINDOW_DAYS = 1
 _DEFAULT_PERIOD = "w"
 
-# GPU/system metrics (stored per-job in JobStatisticDB) normalised to [0, 1]
+# GPU/system metrics (stored per-job in JobStatisticDB) normalized to [0, 1]
 _METRICS_0_1: dict[str, str] = {
     "gpu_sm_occupancy": "SM occupancy",
     "gpu_utilization": "GPU utilization",
@@ -785,9 +785,9 @@ def metrics_rgu_usage(
     metric: str = Query(default="gpu_sm_occupancy"),
     sess: Session = Depends(session_dep),
 ):
-    """Requested vs effectively-used RGU.h per time bucket.
+    """Allocated vs effectively-used RGU.h per time bucket.
 
-    Over GPU jobs submitted in each ``period`` bucket: ``rgu_requested`` =
+    Over GPU jobs submitted in each ``period`` bucket: ``rgu_allocated`` =
     SUM(rgu * elapsed / 3600); ``rgu_used`` = the same scaled by each job's mean
     ``metric`` (e.g. gpu_sm_occupancy). Their gap is wasted GPU capacity. Returns
     one row per bucket.
@@ -796,7 +796,7 @@ def metrics_rgu_usage(
     parsed = _parse_period(period)
     fmt = _label_fmt(parsed)
 
-    # Per bucket: requested = SUM(allocated_gpu_cost)/3600 (the view's precomputed
+    # Per bucket: allocated = SUM(allocated_gpu_cost)/3600 (the view's precomputed
     # RGU-seconds -> RGU-hours); used = the same scaled by the metric mean (NaN
     # nulled to 0). The metric is parametrized over 7 values but the view's *_waste
     # columns are frozen to gpu_sm_occupancy/cpu_utilization, so we read the mean
@@ -814,7 +814,7 @@ def metrics_rgu_usage(
     query = _apply_rgu_base_view(
         select(
             bucket_expr,
-            func.sum(rgu_hours).label("rgu_requested"),
+            func.sum(rgu_hours).label("rgu_allocated"),
             func.sum(rgu_used_term).label("rgu_used"),
             func.sum(rgu_unmeasured_term).label("rgu_unmeasured"),
         ),
@@ -843,7 +843,7 @@ def metrics_rgu_usage(
 
     sums = {
         _sql_bucket_key(parsed, row.bucket): (
-            float(row.rgu_requested or 0.0),
+            float(row.rgu_allocated or 0.0),
             float(row.rgu_used or 0.0),
             float(row.rgu_unmeasured or 0.0),
         )
@@ -852,12 +852,12 @@ def metrics_rgu_usage(
 
     period_data = []
     for key, ps, pe in _iter_buckets(begin_dt, finish_dt, parsed):
-        requested, used, unmeasured = sums.get(key, (0.0, 0.0, 0.0))
+        allocated, used, unmeasured = sums.get(key, (0.0, 0.0, 0.0))
         period_data.append(
             {
                 "period_start": ps.strftime(fmt),
                 "period_end": pe.strftime(fmt),
-                "rgu_requested": requested,
+                "rgu_allocated": allocated,
                 "rgu_used": used,
                 "rgu_unmeasured": unmeasured,
             }

--- a/sarc/api/metrics.py
+++ b/sarc/api/metrics.py
@@ -783,14 +783,16 @@ def metrics_rgu_usage(
     cluster_user: str | None = Query(default=None),
     job_states: list[str] = Query(default=[]),
     metric: str = Query(default="gpu_sm_occupancy"),
+    min_usage: float = Query(default=0.15, ge=0.0, le=1.0),
     sess: Session = Depends(session_dep),
 ):
     """Allocated vs effectively-used RGU.h per time bucket.
 
     Over GPU jobs submitted in each ``period`` bucket: ``rgu_allocated`` =
     SUM(rgu * elapsed / 3600); ``rgu_used`` = the same scaled by each job's mean
-    ``metric`` (e.g. gpu_sm_occupancy). Their gap is wasted GPU capacity. Returns
-    one row per bucket.
+    ``metric`` (e.g. gpu_sm_occupancy); ``rgu_wasted`` = the per-job shortfall
+    below ``min_usage`` (SUM of rgu_hours * (min_usage - mean) over measured
+    jobs with mean < min_usage). Returns one row per bucket.
     """
     begin_dt, finish_dt = _date_range(start, end)
     parsed = _parse_period(period)
@@ -810,6 +812,14 @@ def metrics_rgu_usage(
     m_present = _is_real(m_mean)
     rgu_used_term = case((m_present, rgu_hours * m_mean), else_=0.0)
     rgu_unmeasured_term = case((m_present, 0.0), else_=rgu_hours)
+    # Shortfall to min_usage per job: a job above the threshold contributes 0
+    # (its surplus never offsets another job's deficit), so the SUM is additive
+    # across regroupings -- per-period bars, the whole-range view and a period
+    # change all tell the same story.
+    rgu_wasted_term = case(
+        (and_(m_present, m_mean < min_usage), rgu_hours * (min_usage - m_mean)),
+        else_=0.0,
+    )
 
     query = _apply_rgu_base_view(
         select(
@@ -817,6 +827,7 @@ def metrics_rgu_usage(
             func.sum(rgu_hours).label("rgu_allocated"),
             func.sum(rgu_used_term).label("rgu_used"),
             func.sum(rgu_unmeasured_term).label("rgu_unmeasured"),
+            func.sum(rgu_wasted_term).label("rgu_wasted"),
         ),
         sess,
         clusters,
@@ -846,13 +857,14 @@ def metrics_rgu_usage(
             float(row.rgu_allocated or 0.0),
             float(row.rgu_used or 0.0),
             float(row.rgu_unmeasured or 0.0),
+            float(row.rgu_wasted or 0.0),
         )
         for row in sess.exec(query)
     }
 
     period_data = []
     for key, ps, pe in _iter_buckets(begin_dt, finish_dt, parsed):
-        allocated, used, unmeasured = sums.get(key, (0.0, 0.0, 0.0))
+        allocated, used, unmeasured, wasted = sums.get(key, (0.0, 0.0, 0.0, 0.0))
         period_data.append(
             {
                 "period_start": ps.strftime(fmt),
@@ -860,6 +872,7 @@ def metrics_rgu_usage(
                 "rgu_allocated": allocated,
                 "rgu_used": used,
                 "rgu_unmeasured": unmeasured,
+                "rgu_wasted": wasted,
             }
         )
 

--- a/sarc/api/metrics.py
+++ b/sarc/api/metrics.py
@@ -1345,6 +1345,9 @@ def metrics_jobs(
                 "rgu": round(float(row.rgu), 2),
                 "rgu_hours": round(rh, 2) if rh is not None else None,
                 "waste": waste,
+                # Selected-metric mean (None when unmeasured): drives the
+                # job-table row shading.
+                "metric_mean": mm,
                 "gpu_utilization_mean": _nan_to_none(
                     row.gpu_utilization_mean, replace_with=-1
                 ),

--- a/tests/functional/api/test_metrics.py
+++ b/tests/functional/api/test_metrics.py
@@ -426,6 +426,8 @@ def test_jobs_table_with_data(dash_client, dash_db):
         assert job["rgu"] == pytest.approx(_RGU_PER_JOB)
         assert job["rgu_hours"] == pytest.approx(_RGU_HOURS_PER_JOB)
         assert job["gpu_sm_occupancy_mean"] == pytest.approx(_SM_OCC)
+        # Default metric is gpu_sm_occupancy, so metric_mean mirrors it.
+        assert job["metric_mean"] == pytest.approx(_SM_OCC)
         assert job["gpu_utilization_mean"] == pytest.approx(0.4)
         assert job["gpu_memory_max"] == pytest.approx(0.9)
 

--- a/tests/functional/api/test_metrics.py
+++ b/tests/functional/api/test_metrics.py
@@ -436,6 +436,54 @@ def test_rgu_usage_with_data(dash_client, dash_db):
         dash_db.total_requested
     )
     assert sum(r["rgu_used"] for r in data) == pytest.approx(dash_db.total_used)
+    # Every enriched job runs at 50 % >= the 15 % default min_usage: no shortfall.
+    assert sum(r["rgu_wasted"] for r in data) == 0.0
+
+
+def test_rgu_usage_wasted_is_per_job(dash_client, dash_db):
+    """``rgu_wasted`` sums each job's own shortfall below ``min_usage``: a job
+    above the threshold contributes zero and never offsets a job below it.
+
+    With one job dropped to 2 % and the rest at 50 %, the bucket-aggregated
+    shortfall would be 0 (mean usage is well above 15 %); the per-job one is
+    exactly the low job's deficit.
+    """
+    low_mean = 0.02
+    with config.db.session() as sess:
+        job = sess.exec(
+            select(SlurmJobDB)
+            .where(col(SlurmJobDB.harmonized_gpu_type) == _GPU)
+            .order_by(col(SlurmJobDB.id))
+        ).first()
+        stat = sess.exec(
+            select(JobStatisticDB).where(
+                col(JobStatisticDB.job_id) == job.id,
+                col(JobStatisticDB.name) == "gpu_sm_occupancy",
+            )
+        ).one()
+        stat.mean = low_mean
+        sess.add(stat)
+        sess.commit()
+
+    data = dash_client.get("/dash/metrics/rgu_usage", params=WINDOW).json()
+    assert sum(r["rgu_wasted"] for r in data) == pytest.approx(
+        _RGU_HOURS_PER_JOB * (0.15 - low_mean)
+    )
+    # The shortfall stays within the unused share: no negative bar segment.
+    for r in data:
+        assert (
+            r["rgu_wasted"]
+            <= r["rgu_allocated"] - r["rgu_used"] - r["rgu_unmeasured"] + 1e-9
+        )
+
+    # min_usage is a request parameter: at 60 % every job falls short.
+    data = dash_client.get(
+        "/dash/metrics/rgu_usage", params={**WINDOW, "min_usage": 0.6}
+    ).json()
+    expected = _RGU_HOURS_PER_JOB * (
+        (0.6 - low_mean) + (dash_db.n - 1) * (0.6 - _SM_OCC)
+    )
+    assert sum(r["rgu_wasted"] for r in data) == pytest.approx(expected)
 
 
 def test_rgu_by_cluster_with_data(dash_client, dash_db):
@@ -587,6 +635,8 @@ def test_nan_and_missing_means_never_poison_aggregates(dash_client, dash_db_nan)
     assert sum(r["rgu_unmeasured"] for r in usage) == pytest.approx(
         facts.total_unmeasured
     )
+    # NaN/missing means never count as shortfall (nor do the 50 % good jobs).
+    assert sum(r["rgu_wasted"] for r in usage) == 0.0
 
     # rgu_by_user carries its own copy of the same NaN gate.
     by_user = dash_client.get("/dash/metrics/rgu_by_user", params=WINDOW).json()

--- a/tests/functional/api/test_metrics.py
+++ b/tests/functional/api/test_metrics.py
@@ -213,7 +213,7 @@ _SCOPE_TOTALS = [
     (
         "rgu_usage",
         "/dash/metrics/rgu_usage",
-        lambda d: sum(r["rgu_requested"] for r in d),
+        lambda d: sum(r["rgu_allocated"] for r in d),
     ),
     (
         "rgu_by_cluster",
@@ -310,7 +310,7 @@ EMPTY_ENDPOINTS = [
     (
         "rgu_usage",
         "/dash/metrics/rgu_usage",
-        lambda d: isinstance(d, list) and all(r["rgu_requested"] == 0 for r in d),
+        lambda d: isinstance(d, list) and all(r["rgu_allocated"] == 0 for r in d),
     ),
     ("rgu_by_cluster", "/dash/metrics/rgu_by_cluster", lambda d: d["series"] == []),
     (
@@ -432,7 +432,7 @@ def test_jobs_table_with_data(dash_client, dash_db):
 
 def test_rgu_usage_with_data(dash_client, dash_db):
     data = dash_client.get("/dash/metrics/rgu_usage", params=WINDOW).json()
-    assert sum(r["rgu_requested"] for r in data) == pytest.approx(
+    assert sum(r["rgu_allocated"] for r in data) == pytest.approx(
         dash_db.total_requested
     )
     assert sum(r["rgu_used"] for r in data) == pytest.approx(dash_db.total_used)
@@ -504,8 +504,8 @@ def dash_db_nan(read_write_db):
     "good" (mean 0.5), one with a NaN mean, one with the stat missing entirely.
 
     All four have a valid RGU (GPU type + gres), so all four count in the jobs
-    table and in ``rgu_requested``; only the two good ones may enter a mean-based
-    aggregate. Returns the expected totals.
+    table and in the allocated-RGU totals; only the two good ones may enter a
+    mean-based aggregate. Returns the expected totals.
     """
     sess = read_write_db
     sess.add(GpuRguDB(name=_GPU, rgu=10.0, drac_rgu=_DRAC_RGU))
@@ -575,12 +575,12 @@ def test_nan_and_missing_means_never_poison_aggregates(dash_client, dash_db_nan)
     assert jobs["total"] == facts.n_total
     assert len(jobs["jobs"]) == facts.n_total
 
-    # rgu_usage: requested counts all jobs; used sums only the real means and
+    # rgu_usage: allocated counts all jobs; used sums only the real means and
     # stays finite; the NaN/NULL jobs land in rgu_unmeasured, not rgu_used.
     usage = dash_client.get("/dash/metrics/rgu_usage", params=WINDOW).json()
     used = sum(r["rgu_used"] for r in usage)
     assert math.isfinite(used)
-    assert sum(r["rgu_requested"] for r in usage) == pytest.approx(
+    assert sum(r["rgu_allocated"] for r in usage) == pytest.approx(
         facts.total_requested
     )
     assert used == pytest.approx(facts.total_used)


### PR DESCRIPTION
- Rename page title: "Global Job Metrics" => "Utilization dashboard"
- Make sure to get data only in interval `[start, end)`, nothing else (current dashboard looks in `[start, end + 1 day)`)
- Change admin default layout: it's now user layout + supplementary line with plots `[metric trend, RGU by user]`
- Plot "Job table":
  - Rename column "SM occ waste (rgu.w)" to "Unused (rgu.w)"
  - Add columns "rgu.h" and "Unused (rgu.h)" along with "rgu.w" and "Unused (rgu.w)", to display RGU*time values in both hour and week. Do not display these 2 additional columns if dashboard period is already in hours.
  - Display column "GPU utilization" for everyone
  - Hide column "billing"
  - Display admin-only column headers with a specific dark-red color and add suffix " (admin-only column)" to header titles
  - Add background color to columns:
    - lighter red for jobs < 15 % sm_occupancy
    - medium red for jobs < 5 % sm_occupancy
  - Explicitly display NaN for SM occupancy and GPU utilization (thus, we may not seen NaN anymore, thanks to recent data curation)
  - Improve header and footer:
    - Move jobs count label and column choice dropdown to the right of plot title in header.
    - Rename page size choice dropdown from "rows" to "Jobs per page" and move it to the right of pagination in footer.
- Plot RGU usage:
  - Rename plot "RGU requested vs used" => "RGU allocated vs used"
  - Display red bar "wasted (below 15% min)": part of unused RGU missing to reach at least 15 % or SM occupancy. Waste under 15% is computed per-job in backend code, then sum-ed in frontend bars.
  - Add help button "(?)" which displays an help on hover about wasted and unused semantic.
  - Improve plot visually to match `RGU by cluster` vertical alignments.
