### PR TITLE
Add user-friendly units and use RGU-w in user notifications

### DIFF
--- a/config/sarc-ref.yaml
+++ b/config/sarc-ref.yaml
@@ -101,13 +101,13 @@ sarc:
       channel: slack-channel-id-replace-me # The slack channel ID to message
     underusage_report_template:
       "" # Template for the per-user underusage DM body; placeholders: {name},
-      # {window_weeks}, {window_range}, {avg_utilization},
-      # {rgu_hours_allocated}, {rgu_hours_wasted}, {avg_utilization},
+      # {window_weeks}, {window_range}, {rgu_allocated}, {user_allocated},
+      # {rgu_wasted}, {user_wasted}, {avg_utilization}, {rgu_unit}, {user_unit},
       # {top_jobs_count}, {jobs_section}, {dashboard_url}.
     usage_report_template:
       "" # Template for the neutral usage report body; placeholders: {name},
-      # {window_weeks}, {window_range}, {avg_utilization},
-      # {rgu_hours_allocated}, {avg_utilization}, {top_jobs_count},
+      # {window_weeks}, {window_range}, {rgu_allocated}, {user_allocated},
+      # {avg_utilization}, {rgu_unit}, {user_unit}, {top_jobs_count},
       # {jobs_section}, {dashboard_url}.
     dashboard_url: dashboard-url-replace-me # Dashboard link inserted into user-facing messages
     enabled: True # Master switch; when False the notify command is a no-op

--- a/sarc/cli/notify/usage.py
+++ b/sarc/cli/notify/usage.py
@@ -162,12 +162,15 @@ class UsageNotifyCommand:
             logger.warning(
                 "Restricting this run to a single user (%s); min_waste_ratio, "
                 "min_waste_rgu_hours, and usage_report_min_usage_rgu_hours are "
-                "auto-zeroed for this run unless explicitly overridden",
+                "auto-zeroed for this run unless explicitly overridden, and "
+                "send_underusage_report/send_usage_report are set to True",
                 self.user_email,
             )
             config_overrides["min_waste_ratio"] = 0.0
             config_overrides["min_waste_rgu_hours"] = 0.0
             config_overrides["usage_report_min_usage_rgu_hours"] = 0.0
+            config_overrides["send_underusage_report"] = True
+            config_overrides["send_usage_report"] = True
 
         if self.min_waste_ratio is not None:
             logger.warning(
@@ -290,38 +293,6 @@ class UsageNotifyCommand:
             user_emails=user_emails,
         )
 
-        # --user-email restricts this run to a single test user: skip computing
-        # the fleet-wide recurring-underusers/admin-digest data (and therefore
-        # also the preview print and the later channel post) entirely — only the
-        # per-user DM(s) above should go out.
-        if self.user_email is None:
-            recurring = get_recurring_underusers(
-                end,
-                min_waste_ratio=ncfg.min_waste_ratio,
-                min_waste_rgu_hours=ncfg.min_waste_rgu_hours,
-                cluster_share_threshold=ncfg.recurrence_cluster_share,
-                recurrence_display_cycles=ncfg.recurrence_display_cycles,
-                recurrence_active_cycles=ncfg.recurrence_active_cycles,
-                clusters=clusters,
-                utilization_ceiling=ncfg.utilization_ceiling,
-                personalized_action_min_waste_rgu_hours=ncfg.personalized_action_min_waste_rgu_hours,
-            )
-
-            cycle_dates = get_cycle_dates(end, ncfg.recurrence_display_cycles)
-            digest = build_admin_digest(
-                underusage_rows,
-                period=period,
-                cluster_share_threshold=ncfg.recurrence_cluster_share,
-                active_cycles=ncfg.recurrence_active_cycles,
-                top_n=ncfg.digest_top_n,
-                recurring=recurring,
-                cycle_dates=cycle_dates,
-            )
-            _userfacing_print("=== Admin Digest ===")
-            _userfacing_print(digest)
-        else:
-            digest = None
-
         if underusage_rows and underusage_report_eligible:
             _userfacing_print()
             _userfacing_print("=== Under Usage Report Previews ===")
@@ -362,6 +333,38 @@ class UsageNotifyCommand:
                     )
                     _userfacing_print(report_text)
 
+        # --user-email restricts this run to a single test user: skip computing
+        # the fleet-wide recurring-underusers/admin-digest data (and therefore
+        # also the preview print and the later channel post) entirely — only the
+        # per-user DM(s) above should go out.
+        if self.user_email is None:
+            recurring = get_recurring_underusers(
+                end,
+                min_waste_ratio=ncfg.min_waste_ratio,
+                min_waste_rgu_hours=ncfg.min_waste_rgu_hours,
+                cluster_share_threshold=ncfg.recurrence_cluster_share,
+                recurrence_display_cycles=ncfg.recurrence_display_cycles,
+                recurrence_active_cycles=ncfg.recurrence_active_cycles,
+                clusters=clusters,
+                utilization_ceiling=ncfg.utilization_ceiling,
+                personalized_action_min_waste_rgu_hours=ncfg.personalized_action_min_waste_rgu_hours,
+            )
+
+            cycle_dates = get_cycle_dates(end, ncfg.recurrence_display_cycles)
+            digest = build_admin_digest(
+                underusage_rows,
+                period=period,
+                cluster_share_threshold=ncfg.recurrence_cluster_share,
+                active_cycles=ncfg.recurrence_active_cycles,
+                top_n=ncfg.digest_top_n,
+                recurring=recurring,
+                cycle_dates=cycle_dates,
+            )
+            _userfacing_print("=== Admin Digest ===")
+            _userfacing_print(digest)
+        else:
+            digest = None
+
         if not self.send:
             return 0
 
@@ -370,6 +373,7 @@ class UsageNotifyCommand:
         slack_usage_client = SlackClient(ncfg.slack_usage.token)
 
         underusage_report_delivery_results: list[_DeliveryResult] = []
+        usage_report_delivery_results: list[_DeliveryResult] = []
 
         if underusage_report_will_send:
             underusage_report_delivery_results = _deliver(
@@ -386,7 +390,6 @@ class UsageNotifyCommand:
                     _DeliveryResult(row.email, row.display_name, "skipped", reason)
                 )
 
-        usage_report_delivery_results: list[_DeliveryResult] = []
         if usage_report_will_send:
             usage_report_delivery_results = _deliver(
                 usage_rows,
@@ -407,6 +410,7 @@ class UsageNotifyCommand:
 
         underusage_report_footer = None
         usage_report_footer = None
+
         if underusage_report_eligible:
             underusage_report_footer = _build_delivery_footer(
                 underusage_report_delivery_results,
@@ -414,6 +418,7 @@ class UsageNotifyCommand:
                 count_label="flagged",
                 count=len(underusage_rows),
             )
+
         if usage_report_eligible:
             usage_report_footer = _build_delivery_footer(
                 usage_report_delivery_results,

--- a/sarc/config.py
+++ b/sarc/config.py
@@ -270,6 +270,15 @@ class SlackConfig:
 
 
 @dataclass
+class UsageNotifyUnitConfig:
+    unit: str
+    """Short unit label"""
+    unit_long: str
+    """Long unit label"""
+    factor: float = 1.0
+
+
+@dataclass
 class UsageNotifyConfig:
     # Required bot scopes: chat:write, im:write, users:read.email
     slack_underusage: SlackConfig
@@ -283,14 +292,16 @@ class UsageNotifyConfig:
     underusage_report_template: str
     """``.format()``-able template for the per-user underusage report body.
     Placeholders: ``{name}``, ``{window_weeks}``, ``{window_range}``,
-    ``{rgu_hours_allocated}``, ``{rgu_hours_wasted}``, ``{avg_utilization}``,
+    ``{rgu_allocated}``, ``{user_allocated}``, ``{rgu_wasted}``,
+    ``{user_wasted}``, ``{avg_utilization}``, ``{rgu_unit}``, ``{user_unit}``,
     ``{top_jobs_count}``, ``{jobs_section}``, ``{dashboard_url}``."""
 
     usage_report_template: str
     """``.format()``-able template for the neutral usage report body.
     Placeholders: ``{name}``, ``{window_weeks}``, ``{window_range}``,
-    ``{rgu_hours_allocated}``, ``{avg_utilization}``, ``{top_jobs_count}``,
-    ``{jobs_section}``, ``{dashboard_url}``."""
+    ``{rgu_allocated}``, ``{user_allocated}``, ``{avg_utilization}``,
+    ``{rgu_unit}``, ``{top_jobs_count}``, ``{jobs_section}``,
+    ``{dashboard_url}``."""
 
     dashboard_url: str
     """Base link to the usage dashboard; each message appends its own
@@ -364,6 +375,17 @@ class UsageNotifyConfig:
     restrictive-action marker ("!!⚑▲") in the recurring-underusers table.
     Positive int; a value greater than ``recurrence_display_cycles`` simply
     yields no escalation."""
+
+    rgu_unit: UsageNotifyUnitConfig = field(
+        default_factory=lambda: UsageNotifyUnitConfig(
+            "RGU-w", "RGU-weeks", 1 / (24 * 7)
+        )
+    )
+    user_unit: UsageNotifyUnitConfig = field(
+        default_factory=lambda: UsageNotifyUnitConfig(
+            "A100-w", "A100-weeks", 1 / (4.8 * 24 * 7)
+        )
+    )
 
     clusters: list[str] = field(default_factory=lambda: ["mila"])
     """Cluster-name allowlist scoping every query (alerts, usage report,

--- a/sarc/notifications/messages.py
+++ b/sarc/notifications/messages.py
@@ -12,9 +12,13 @@ from sarc.notifications.usage import (
 )
 
 
-def _fmt_rgu_int(hours: float) -> str:
+def _fmt_rgu_int(hours: float, factor: float) -> str:
     """Format RGU-hours as an integer with a space thousands separator."""
-    return f"{int(round(hours)):,}".replace(",", " ")
+    return f"{int(round(hours * factor)):,}".replace(",", " ")
+
+
+def _fmt_rgu(hours: float, factor: float) -> str:
+    return f"{hours * factor:.1f}"
 
 
 def _pct(fraction: float) -> str:
@@ -23,10 +27,6 @@ def _pct(fraction: float) -> str:
 
 def _date_range(start: date, end: date) -> str:
     return f"{start:%b %d, %Y} – {end:%b %d, %Y}"
-
-
-def _fmt_h(hours: float) -> str:
-    return f"{hours:.1f}"
 
 
 def _dashboard_url(base_url: str, start: date, end: date) -> str:
@@ -39,7 +39,9 @@ def _tree_prefix(i: int, n: int) -> str:
     return "┌─" if i == 0 else "├─"
 
 
-def _jobs_section(top_jobs: list, *, rgu_value: Callable, suffix: str) -> str:
+def _jobs_section(
+    top_jobs: list, *, rgu_value: Callable, rgu_factor: float, suffix: str
+) -> str:
     by_cluster: dict[str, list] = defaultdict(list)
     for job in top_jobs:
         by_cluster[job.cluster].append(job)
@@ -64,7 +66,7 @@ def _jobs_section(top_jobs: list, *, rgu_value: Callable, suffix: str) -> str:
             )
             lines.append(
                 f"{prefix} job_{job.job_id} ({date_str})"
-                f" — {_fmt_h(rgu_value(job))} {suffix}"
+                f" — {_fmt_rgu(rgu_value(job), rgu_factor)} {suffix}"
                 f"  (SM occupancy: {util_str})"
             )
     return "\n".join(lines)
@@ -81,12 +83,19 @@ def build_user_dm(
         name=MENTION_TOKEN,
         window_weeks=window_weeks,
         window_range=_date_range(window_start, window_end),
-        rgu_hours_allocated=_fmt_h(row.rgu_hours),
-        rgu_hours_wasted=_fmt_h(row.wasted),
+        rgu_allocated=_fmt_rgu(row.rgu_hours, ncfg.rgu_unit.factor),
+        rgu_wasted=_fmt_rgu(row.wasted, ncfg.rgu_unit.factor),
+        user_allocated=_fmt_rgu(row.rgu_hours, ncfg.user_unit.factor),
+        user_wasted=_fmt_rgu(row.wasted, ncfg.user_unit.factor),
         avg_utilization=_pct(row.avg_utilization),
+        rgu_unit=ncfg.rgu_unit.unit_long,
+        user_unit=ncfg.user_unit.unit_long,
         top_jobs_count=len(row.top_jobs),
         jobs_section=_jobs_section(
-            row.top_jobs, rgu_value=lambda j: j.wasted, suffix="RGU-h unused"
+            row.top_jobs,
+            rgu_value=lambda j: j.wasted,
+            rgu_factor=ncfg.rgu_unit.factor,
+            suffix=f"{ncfg.rgu_unit.unit} unused",
         ),
         dashboard_url=_dashboard_url(ncfg.dashboard_url, window_start, window_end),
     ).rstrip()
@@ -107,11 +116,17 @@ def build_usage_report(
         name=MENTION_TOKEN,
         window_weeks=window_weeks,
         window_range=_date_range(window_start, window_end),
-        rgu_hours_allocated=_fmt_h(row.rgu_hours),
+        rgu_allocated=_fmt_rgu(row.rgu_hours, ncfg.rgu_unit.factor),
+        user_allocated=_fmt_rgu(row.rgu_hours, ncfg.user_unit.factor),
         avg_utilization=_pct(row.avg_utilization),
+        rgu_unit=ncfg.rgu_unit.unit_long,
+        user_unit=ncfg.user_unit.unit_long,
         top_jobs_count=len(row.top_jobs),
         jobs_section=_jobs_section(
-            row.top_jobs, rgu_value=lambda j: j.rgu_hours_used, suffix="RGU-h"
+            row.top_jobs,
+            rgu_value=lambda j: j.rgu_hours_used,
+            rgu_factor=ncfg.rgu_unit.factor,
+            suffix=ncfg.rgu_unit.unit,
         ),
         dashboard_url=_dashboard_url(ncfg.dashboard_url, window_start, window_end),
     ).rstrip()
@@ -143,6 +158,10 @@ def build_recurring_table(
     """
     if not recurring:
         return ""
+
+    if not config.notifications:
+        raise ConfigurationError("No notifications configuration found in config")
+    ncfg = config.notifications
 
     cycle_length_weeks = usage_cycle_length_weeks()
     window_weeks = active_cycles * cycle_length_weeks
@@ -222,7 +241,7 @@ def build_recurring_table(
             flags = _build_flag_cells(row)
             lines.append(
                 f"{pfx} {row.email:<{email_w}}"
-                f"  {_fmt_rgu_int(row.wasted_current_active_window):>12}"
+                f"  {_fmt_rgu_int(row.wasted_current_active_window, ncfg.rgu_unit.factor):>12}"
                 f"  {row.cluster_share * 100:>3.0f} %" + flags
             )
 
@@ -246,6 +265,10 @@ def build_admin_digest(
     Ranks underusers by RGU-hours wasted (descending), capped at top_n.
     Pure function — no I/O, deterministic for fixed input.
     """
+    if not config.notifications:
+        raise ConfigurationError("No notifications configuration found in config")
+    ncfg = config.notifications
+
     ranked = sorted(rows, key=lambda r: r.wasted, reverse=True)[:top_n]
 
     lines = [
@@ -255,7 +278,7 @@ def build_admin_digest(
     ]
 
     clusters = [r.by_cluster[0].cluster if r.by_cluster else "unknown" for r in ranked]
-    wasted_s = [_fmt_h(r.wasted) for r in ranked]
+    wasted_s = [_fmt_rgu(r.wasted, ncfg.rgu_unit.factor) for r in ranked]
     ratio_s = [_pct(r.waste_ratio) for r in ranked]
 
     if ranked:
@@ -273,7 +296,7 @@ def build_admin_digest(
                 f"{row.display_name.ljust(name_w)}  "
                 f"{row.email.ljust(email_w)}  "
                 f"{cluster.ljust(cluster_w)}  "
-                f"{ws.rjust(wasted_w)} RGU-h unused  "
+                f"{ws.rjust(wasted_w)} {ncfg.rgu_unit.unit} unused  "
                 f"{rs.rjust(ratio_w)}"
             )
 

--- a/tests/unittests/notifications/_factory.py
+++ b/tests/unittests/notifications/_factory.py
@@ -18,7 +18,8 @@ _REPO_ROOT = Path(__file__).parent.parent.parent.parent
 
 
 UNDERUSAGE_REPORT_TEMPLATE = """{name}
-{window_weeks} {window_range} {rgu_hours_allocated} RGU-hours {avg_utilization} leaving {rgu_hours_wasted} RGU-hours unused
+{window_weeks} {window_range} {rgu_allocated} {rgu_unit} {avg_utilization}
+leaving {rgu_wasted} {rgu_unit} unused (or about {user_wasted} {user_unit})
 top_jobs_count:{top_jobs_count}
 ```
 {jobs_section}
@@ -28,7 +29,8 @@ Track your usage over time: {dashboard_url}
 
 
 USAGE_REPORT_TEMPLATE = """{name}
-{window_weeks} {window_range} {rgu_hours_allocated} RGU-hours {avg_utilization}
+{window_weeks} {window_range} {rgu_allocated} {rgu_unit} (or about
+{user_allocated} {user_unit}) {avg_utilization}
 top_jobs_count:{top_jobs_count}
 ```
 {jobs_section}

--- a/tests/unittests/notifications/test_cli.py
+++ b/tests/unittests/notifications/test_cli.py
@@ -540,7 +540,9 @@ def test_usage_report_week_underuser_not_in_report_previews(
         )
     ]
     assert "petitbonhomme@mila.quebec" in dm_section
-    usage_section = out[out.find("=== Usage Report Previews") :]
+    usage_section = out[
+        out.find("=== Usage Report Previews") : out.find("=== Admin Digest ===")
+    ]
     assert "petitbonhomme@mila.quebec" not in usage_section
     assert "beaubonhomme@mila.quebec" in usage_section
     # Regression: the usage-report query excludes underusers at the DB level, so

--- a/tests/unittests/notifications/test_messages.py
+++ b/tests/unittests/notifications/test_messages.py
@@ -6,7 +6,7 @@ import pytest
 from sarc.config import ConfigurationError
 from sarc.notifications.messages import (
     _date_range,
-    _fmt_h,
+    _fmt_rgu,
     _jobs_section,
     _pct,
     build_admin_digest,
@@ -130,7 +130,9 @@ def _build_usage_report(row, *, window_weeks):
 
 def test_usage_report():
     window_weeks = 4
-    with _notify_overlay(dashboard_url="https://dash.example.com"):
+    with _notify_overlay(dashboard_url="https://dash.example.com") as config:
+        rgu_unit = config.sarc.notifications.rgu_unit
+        user_unit = config.sarc.notifications.user_unit
         text = _build_usage_report(_USAGE_ROW_ALICE, window_weeks=window_weeks)
     # Ensure no formatting braces {} remain
     assert "{" not in text
@@ -142,7 +144,13 @@ def test_usage_report():
     # Test overview contains the real date range
     assert _date_range(_WINDOW_START, _WINDOW_END) in text
     # Test overview contains rgu used
-    assert _fmt_h(_USAGE_ROW_ALICE.rgu_hours) in text
+    assert _fmt_rgu(_USAGE_ROW_ALICE.rgu_hours, rgu_unit.factor) in text
+    # Test overview contains rgu long unit
+    assert rgu_unit.unit_long in text
+    # Test overview contains user friendly used
+    assert _fmt_rgu(_USAGE_ROW_ALICE.rgu_hours, user_unit.factor) in text
+    # Test overview contains user friendly long unit
+    assert user_unit.unit_long in text
     # Test overview contains utilization
     assert _pct(_USAGE_ROW_ALICE.avg_utilization) in text
     # Test overview contains top jobs count
@@ -155,7 +163,8 @@ def test_usage_report():
         _jobs_section(
             _USAGE_ROW_ALICE.top_jobs,
             rgu_value=lambda j: j.rgu_hours_used,
-            suffix="RGU-h",
+            rgu_factor=rgu_unit.factor,
+            suffix=rgu_unit.unit,
         )
         in text
     )
@@ -243,7 +252,9 @@ def _build_user_dm(row, *, window_weeks):
 
 def test_underusage_report():
     window_weeks = 2
-    with _notify_overlay():
+    with _notify_overlay() as config:
+        rgu_unit = config.sarc.notifications.rgu_unit
+        user_unit = config.sarc.notifications.user_unit
         text = _build_user_dm(_ROW_ALICE, window_weeks=window_weeks)
     # Ensure no formatting braces {} remain
     assert "{" not in text
@@ -255,20 +266,29 @@ def test_underusage_report():
     # Test overview contains the real date range
     assert _date_range(_WINDOW_START, _WINDOW_END) in text
     # Test overview contains rgu used
-    assert _fmt_h(_USAGE_ROW_ALICE.rgu_hours) in text
+    assert _fmt_rgu(_ROW_ALICE.rgu_hours, rgu_unit.factor) in text
+    # Test overview contains rgu long unit
+    assert rgu_unit.unit_long in text
     # Test overview contains utilization
     assert _pct(_ROW_ALICE.avg_utilization) in text
     # Test overview contains unused hours
-    assert _fmt_h(_ROW_ALICE.wasted) in text
+    assert _fmt_rgu(_ROW_ALICE.wasted, rgu_unit.factor) in text
+    # Test overview contains user friendly used
+    assert _fmt_rgu(_ROW_ALICE.wasted, user_unit.factor) in text
+    # Test overview contains user friendly long unit
+    assert user_unit.unit_long in text
     # Test overview contains top jobs count
-    assert f"top_jobs_count:{len(_USAGE_ROW_ALICE.top_jobs)}" in text
+    assert f"top_jobs_count:{len(_ROW_ALICE.top_jobs)}" in text
     # Test top jobs grouped by cluster
     # narval block appears before fir block (narval has more total waste)
     assert text.index("Cluster narval") < text.index("Cluster fir")
     # Test job line format
     assert (
         _jobs_section(
-            _ROW_ALICE.top_jobs, rgu_value=lambda j: j.wasted, suffix="RGU-h unused"
+            _ROW_ALICE.top_jobs,
+            rgu_value=lambda j: j.wasted,
+            rgu_factor=rgu_unit.factor,
+            suffix=f"{rgu_unit.unit} unused",
         )
         in text
     )
@@ -288,23 +308,26 @@ _DIGEST_KW = {"cluster_share_threshold": 0.30, "active_cycles": 3, "top_n": 16}
 
 
 def test_digest_header_contains_period():
-    text = build_admin_digest(
-        [_ROW_ALICE, _ROW_BOB], period="2026-05-21 to 2026-06-04", **_DIGEST_KW
-    )
+    with _notify_overlay():
+        text = build_admin_digest(
+            [_ROW_ALICE, _ROW_BOB], period="2026-05-21 to 2026-06-04", **_DIGEST_KW
+        )
     assert "2026-05-21 to 2026-06-04" in text
 
 
 def test_digest_count_line():
-    text = build_admin_digest(
-        [_ROW_ALICE, _ROW_BOB, _ROW_CAROL], period="…", **_DIGEST_KW
-    )
+    with _notify_overlay():
+        text = build_admin_digest(
+            [_ROW_ALICE, _ROW_BOB, _ROW_CAROL], period="…", **_DIGEST_KW
+        )
     assert "3 user(s) flagged" in text
 
 
 def test_digest_ranked_by_wasted_descending():
-    text = build_admin_digest(
-        [_ROW_ALICE, _ROW_BOB, _ROW_CAROL], period="…", **_DIGEST_KW
-    )
+    with _notify_overlay():
+        text = build_admin_digest(
+            [_ROW_ALICE, _ROW_BOB, _ROW_CAROL], period="…", **_DIGEST_KW
+        )
     # Bob: 600 wasted, Carol: 420, Alice: 245 → Bob is rank 1
     assert (
         text.index("Bob Marley")
@@ -314,36 +337,42 @@ def test_digest_ranked_by_wasted_descending():
 
 
 def test_digest_capped_at_top_n():
-    text = build_admin_digest(
-        [_ROW_ALICE, _ROW_BOB, _ROW_CAROL], period="…", **{**_DIGEST_KW, "top_n": 2}
-    )
+    with _notify_overlay():
+        text = build_admin_digest(
+            [_ROW_ALICE, _ROW_BOB, _ROW_CAROL], period="…", **{**_DIGEST_KW, "top_n": 2}
+        )
     assert "Alice Liddell" not in text  # rank 3 — excluded
     assert "Bob Marley" in text
     assert "Carol Danvers" in text
 
 
 def test_digest_contains_primary_cluster():
-    text = build_admin_digest([_ROW_ALICE], period="…", **_DIGEST_KW)
+    with _notify_overlay():
+        text = build_admin_digest([_ROW_ALICE], period="…", **_DIGEST_KW)
     assert "narval" in text
 
 
 def test_digest():
-    text = build_admin_digest([_ROW_BOB], period="…", **_DIGEST_KW)
+    with _notify_overlay() as config:
+        rgu_unit = config.sarc.notifications.rgu_unit
+        text = build_admin_digest([_ROW_BOB], period="…", **_DIGEST_KW)
     # Test contains unused hours
-    assert "600.0 RGU-h unused" in text
+    assert f"{_fmt_rgu(600.0, rgu_unit.factor)} {rgu_unit.unit} unused" in text
     # Test contains waste ratio
     assert "75.0 %" in text
 
 
 def test_digest_deterministic():
     rows = [_ROW_ALICE, _ROW_BOB]
-    assert build_admin_digest(rows, period="p", **_DIGEST_KW) == build_admin_digest(
-        rows, period="p", **_DIGEST_KW
-    )
+    with _notify_overlay():
+        assert build_admin_digest(rows, period="p", **_DIGEST_KW) == build_admin_digest(
+            rows, period="p", **_DIGEST_KW
+        )
 
 
 def test_digest_empty_rows():
-    text = build_admin_digest([], period="…", **_DIGEST_KW)
+    with _notify_overlay():
+        text = build_admin_digest([], period="…", **_DIGEST_KW)
     assert "0 user(s) flagged" in text
 
 
@@ -368,6 +397,13 @@ def test_digest_recurring_header_reflects_share():
             recurring={"narval": [row]},
         )
     assert "40 %" in text
+
+
+def test_digest_raises_without_notifications_config():
+    with pytest.raises(ConfigurationError, match="No notifications configuration"):
+        build_admin_digest(
+            [], period="", cluster_share_threshold=0.0, active_cycles=0, top_n=0
+        )
 
 
 # ── build_recurring_table direct tests ───────────────────────────────────────
@@ -469,3 +505,10 @@ def test_recurring_table_all_empty_clusters_returns_empty_string():
             {"cluster1": [], "cluster2": []}, **_RECURRING_KW_DEFAULT
         )
     assert text == ""
+
+
+def test_recurring_table_raises_without_notifications_config():
+    with pytest.raises(ConfigurationError, match="No notifications configuration"):
+        build_recurring_table(
+            {"cluster1": []}, cluster_share_threshold=0.0, active_cycles=1
+        )

--- a/tests/unittests/notifications/test_recurring.py
+++ b/tests/unittests/notifications/test_recurring.py
@@ -8,7 +8,7 @@ from sqlmodel import select
 
 from sarc.db.cluster import SlurmClusterDB
 from sarc.db.users import UserDB
-from sarc.notifications.messages import build_recurring_table
+from sarc.notifications.messages import _fmt_rgu_int, build_recurring_table
 from sarc.notifications.usage import (
     RecurringUserRow,
     _week_anchor,
@@ -403,9 +403,10 @@ def test_table_contains_email():
 
 
 def test_table_wasted_formatted_with_space_thousands():
-    with gifnoc.overlay({"sarc.notifications": _NOTIFY_CFG}):
+    with gifnoc.overlay({"sarc.notifications": _NOTIFY_CFG}) as config:
+        rgu_unit = config.sarc.notifications.rgu_unit
         text = build_recurring_table({"narval": [_ROW_ALICE]}, **_BRT_KW)
-    assert "4 200" in text
+    assert _fmt_rgu_int(4200, rgu_unit.factor) in text
 
 
 def test_table_share_percentage():


### PR DESCRIPTION
## Summary
Adds configurable, human-friendly unit conversions (e.g. RGU-weeks, A100-weeks) to underusage/usage notification messages instead of raw RGU-hours, and fixes a bug where `--user-email` test runs skipped sending the actual reports.

## Changes
- New `UsageNotifyUnitConfig` dataclass (`sarc/config.py`) with `unit`, `unit_long`, and `factor`; `UsageNotifyConfig` gains `rgu_unit` (default RGU-w) and `user_unit` (default A100-w) fields.
- `sarc/notifications/messages.py`: replaces `_fmt_h`/`_fmt_rgu_int(hours)` with unit-aware `_fmt_rgu(hours, factor)` / `_fmt_rgu_int(hours, factor)`; template placeholders renamed/expanded (`{rgu_allocated}`, `{user_allocated}`, `{rgu_wasted}`, `{user_wasted}`, `{rgu_unit}`, `{user_unit}`) across `build_user_dm`, `build_usage_report`, `build_recurring_table`, and `build_admin_digest`.
- `build_recurring_table` and `build_admin_digest` now require a `notifications` config section and raise `ConfigurationError` if missing.
- `sarc/cli/notify/usage.py`: fixes `--user-email` single-user test runs to also force `send_underusage_report`/`send_usage_report` to `True`, and moves the admin-digest computation/preview after the usage-report preview block (ordering fix, no behavior change to what's computed).
- Updates `config/sarc-ref.yaml` template placeholder docs to match the new placeholders.
- Updates tests and the test template factory (`tests/unittests/notifications/_factory.py`) for the new placeholders and config requirement.

## Notes
Existing deployed config templates that reference `{rgu_hours_allocated}` / `{rgu_hours_wasted}` will need to be updated to the new placeholder names.