### PR TITLE
Unify top_jobs/bottom_jobs semantics in usage notifications

### DIFF
--- a/config/sarc-ref.yaml
+++ b/config/sarc-ref.yaml
@@ -103,12 +103,13 @@ sarc:
       "" # Template for the per-user underusage DM body; placeholders: {name},
       # {window_weeks}, {window_range}, {rgu_allocated}, {user_allocated},
       # {rgu_wasted}, {user_wasted}, {avg_utilization}, {rgu_unit}, {user_unit},
-      # {top_jobs_count}, {jobs_section}, {dashboard_url}.
+      # {bottom_jobs_count}, {bottom_jobs_section}, {dashboard_url}.
     usage_report_template:
       "" # Template for the neutral usage report body; placeholders: {name},
       # {window_weeks}, {window_range}, {rgu_allocated}, {user_allocated},
       # {avg_utilization}, {rgu_unit}, {user_unit}, {top_jobs_count},
-      # {jobs_section}, {dashboard_url}.
+      # {top_jobs_section}, {bottom_jobs_count}, {bottom_jobs_section},
+      # {dashboard_url}.
     dashboard_url: dashboard-url-replace-me # Dashboard link inserted into user-facing messages
     enabled: True # Master switch; when False the notify command is a no-op
     send_underusage_report: True # Enable the user underusage DMs and the admin digest
@@ -118,7 +119,7 @@ sarc:
     # --- Individual underusage alerts (user DMs) ---
     min_waste_ratio: 0.50 # Min scaled waste ratio (1 - effective_util) to flag a user
     min_waste_rgu_hours: 3225.6 # Min scaled wasted RGU-h to flag a user (~4x A100-80GB RGU x 7d)
-    top_jobs_per_user: 5 # Number of a user's worst jobs shown per user
+    max_jobs_per_user: 5 # Max jobs shown per per-user job list (underusage DM's worst jobs; usage report's best- and worst-jobs lists)
     # --- Universal usage report (neutral, all active GPU users) ---
     usage_report_cycles: 2 # Usage-report window length, in usage cycles
     usage_report_min_usage_rgu_hours: 1843.2 # Min occupied (used+wasted) RGU-h to include a user (~4x A100-80GB RGU x 4d)
@@ -133,6 +134,15 @@ sarc:
       # the (n-1) cycles following it — that escalate to a restrictive-action
       # marker ("!!⚑▲") in the recurring-underusers table; a value greater than
       # recurrence_display_cycles yields no escalation
+
+    rgu_unit: # Display unit for RGU-hour quantities (rgu_allocated/rgu_wasted in templates)
+      unit: RGU-w # Short label
+      unit_long: RGU-weeks # Long label
+      hours_per_unit: 168 # RGU-hours per unit; 24*7 hours in a week -> unit = "RGU-week"
+    user_unit: # Same quantities re-expressed in A100-equivalent terms (user_allocated/user_wasted)
+      unit: A100-w # Short label
+      unit_long: A100-weeks # Long label
+      hours_per_unit: 806.4 # RGU-hours per unit; 1x A100-80GB ≈ 4.8 RGU, so 4.8*24*7 -> unit = "A100-week"
 
     clusters: # Cluster-name allowlist scoping every query; empty list = all clusters
       - mila

--- a/sarc/cli/usage/notify.py
+++ b/sarc/cli/usage/notify.py
@@ -303,7 +303,7 @@ class UsageNotifyCommand:
             end,
             min_waste_ratio=ncfg.min_waste_ratio,
             min_waste_rgu_hours=ncfg.min_waste_rgu_hours,
-            top_jobs_per_user=ncfg.top_jobs_per_user,
+            max_jobs_per_user=ncfg.max_jobs_per_user,
             clusters=clusters,
             utilization_ceiling=ncfg.utilization_ceiling,
             user_emails=user_emails,
@@ -330,7 +330,7 @@ class UsageNotifyCommand:
                 usage_start,
                 end,
                 min_usage_rgu_hours=ncfg.usage_report_min_usage_rgu_hours,
-                top_jobs_per_user=ncfg.top_jobs_per_user,
+                max_jobs_per_user=ncfg.max_jobs_per_user,
                 clusters=clusters,
                 user_emails=_user_emails,
             )

--- a/sarc/config.py
+++ b/sarc/config.py
@@ -275,7 +275,7 @@ class UsageNotifyUnitConfig:
     """Short unit label"""
     unit_long: str
     """Long unit label"""
-    factor: float = 1.0
+    hours_per_unit: float = 1.0
 
 
 @dataclass
@@ -294,13 +294,14 @@ class UsageNotifyConfig:
     Placeholders: ``{name}``, ``{window_weeks}``, ``{window_range}``,
     ``{rgu_allocated}``, ``{user_allocated}``, ``{rgu_wasted}``,
     ``{user_wasted}``, ``{avg_utilization}``, ``{rgu_unit}``, ``{user_unit}``,
-    ``{top_jobs_count}``, ``{jobs_section}``, ``{dashboard_url}``."""
+    ``{bottom_jobs_count}``, ``{bottom_jobs_section}``, ``{dashboard_url}``."""
 
     usage_report_template: str
     """``.format()``-able template for the neutral usage report body.
     Placeholders: ``{name}``, ``{window_weeks}``, ``{window_range}``,
     ``{rgu_allocated}``, ``{user_allocated}``, ``{avg_utilization}``,
-    ``{rgu_unit}``, ``{top_jobs_count}``, ``{jobs_section}``,
+    ``{rgu_unit}``, ``{top_jobs_count}``, ``{top_jobs_section}``,
+    ``{bottom_jobs_count}``, ``{bottom_jobs_section}``,
     ``{dashboard_url}``."""
 
     dashboard_url: str
@@ -338,9 +339,10 @@ class UsageNotifyConfig:
     floor that suppresses trivially small waste. Default ≈ 4× A100-80GB RGU ×
     7d."""
 
-    top_jobs_per_user: int = 5
-    """Number of a user's worst jobs shown per user in the underusage DM.
-    Positive int."""
+    max_jobs_per_user: int = 5
+    """Number of jobs shown per user in each per-user job list — the
+    underusage DM's worst jobs, and the usage report's most- and
+    least-efficient job lists. Positive int."""
 
     usage_report_cycles: int = 2
     """Length of the usage-report window in usage cycles (window =
@@ -382,15 +384,23 @@ class UsageNotifyConfig:
     yields no escalation."""
 
     rgu_unit: UsageNotifyUnitConfig = field(
-        default_factory=lambda: UsageNotifyUnitConfig(
-            "RGU-w", "RGU-weeks", 1 / (24 * 7)
-        )
+        default_factory=lambda: UsageNotifyUnitConfig("RGU-w", "RGU-weeks", 24 * 7)
     )
+    """Display unit for raw RGU-hour quantities (``rgu_allocated``/``rgu_wasted``
+    in the templates). ``hours_per_unit`` divides stored RGU-hours down into
+    this unit. Default ``hours_per_unit=24*7`` (hours in a week) makes the
+    unit an "RGU-week"."""
+
     user_unit: UsageNotifyUnitConfig = field(
         default_factory=lambda: UsageNotifyUnitConfig(
-            "A100-w", "A100-weeks", 1 / (4.8 * 24 * 7)
+            "A100-w", "A100-weeks", 4.8 * 24 * 7
         )
     )
+    """Display unit for the same RGU-hour quantities re-expressed in
+    "A100-equivalent" terms (``user_allocated``/``user_wasted``), for readers
+    who don't think in RGU. Default ``hours_per_unit=4.8*24*7`` uses 1x
+    A100-80GB ≈ 4.8 RGU, so the unit is one A100-80GB running for a week
+    ("A100-week")."""
 
     clusters: list[str] = field(default_factory=lambda: ["mila"])
     """Cluster-name allowlist scoping every query (alerts, usage report,

--- a/sarc/notifications/messages.py
+++ b/sarc/notifications/messages.py
@@ -12,13 +12,13 @@ from sarc.notifications.usage import (
 )
 
 
-def _fmt_rgu_int(hours: float, factor: float) -> str:
+def _fmt_rgu_int(hours: float, hours_per_unit: float) -> str:
     """Format RGU-hours as an integer with a space thousands separator."""
-    return f"{int(round(hours * factor)):,}".replace(",", " ")
+    return f"{int(round(hours / hours_per_unit)):,}".replace(",", " ")
 
 
-def _fmt_rgu(hours: float, factor: float) -> str:
-    return f"{hours * factor:.1f}"
+def _fmt_rgu(hours: float, hours_per_unit: float) -> str:
+    return f"{hours / hours_per_unit:.1f}"
 
 
 def _pct(fraction: float) -> str:
@@ -40,10 +40,10 @@ def _tree_prefix(i: int, n: int) -> str:
 
 
 def _jobs_section(
-    top_jobs: list, *, rgu_value: Callable, rgu_factor: float, suffix: str
+    jobs: list, *, rgu_value: Callable, hours_per_unit: float, suffix: str
 ) -> str:
     by_cluster: dict[str, list] = defaultdict(list)
-    for job in top_jobs:
+    for job in jobs:
         by_cluster[job.cluster].append(job)
 
     cluster_order = sorted(
@@ -66,7 +66,7 @@ def _jobs_section(
             )
             lines.append(
                 f"{prefix} job_{job.job_id} ({date_str})"
-                f" — {_fmt_rgu(rgu_value(job), rgu_factor)} {suffix}"
+                f" — {_fmt_rgu(rgu_value(job), hours_per_unit)} {suffix}"
                 f"  (SM occupancy: {util_str})"
             )
     return "\n".join(lines)
@@ -83,18 +83,18 @@ def build_user_dm(
         name=MENTION_TOKEN,
         window_weeks=window_weeks,
         window_range=_date_range(window_start, window_end),
-        rgu_allocated=_fmt_rgu(row.rgu_hours, ncfg.rgu_unit.factor),
-        rgu_wasted=_fmt_rgu(row.wasted, ncfg.rgu_unit.factor),
-        user_allocated=_fmt_rgu(row.rgu_hours, ncfg.user_unit.factor),
-        user_wasted=_fmt_rgu(row.wasted, ncfg.user_unit.factor),
+        rgu_allocated=_fmt_rgu(row.rgu_hours, ncfg.rgu_unit.hours_per_unit),
+        rgu_wasted=_fmt_rgu(row.wasted, ncfg.rgu_unit.hours_per_unit),
+        user_allocated=_fmt_rgu(row.rgu_hours, ncfg.user_unit.hours_per_unit),
+        user_wasted=_fmt_rgu(row.wasted, ncfg.user_unit.hours_per_unit),
         avg_utilization=_pct(row.avg_utilization),
         rgu_unit=ncfg.rgu_unit.unit_long,
         user_unit=ncfg.user_unit.unit_long,
-        top_jobs_count=len(row.top_jobs),
-        jobs_section=_jobs_section(
-            row.top_jobs,
+        bottom_jobs_count=len(row.bottom_jobs),
+        bottom_jobs_section=_jobs_section(
+            row.bottom_jobs,
             rgu_value=lambda j: j.wasted,
-            rgu_factor=ncfg.rgu_unit.factor,
+            hours_per_unit=ncfg.rgu_unit.hours_per_unit,
             suffix=f"{ncfg.rgu_unit.unit} unused",
         ),
         dashboard_url=_dashboard_url(ncfg.dashboard_url, window_start, window_end),
@@ -116,17 +116,24 @@ def build_usage_report(
         name=MENTION_TOKEN,
         window_weeks=window_weeks,
         window_range=_date_range(window_start, window_end),
-        rgu_allocated=_fmt_rgu(row.rgu_hours, ncfg.rgu_unit.factor),
-        user_allocated=_fmt_rgu(row.rgu_hours, ncfg.user_unit.factor),
+        rgu_allocated=_fmt_rgu(row.rgu_hours, ncfg.rgu_unit.hours_per_unit),
+        user_allocated=_fmt_rgu(row.rgu_hours, ncfg.user_unit.hours_per_unit),
         avg_utilization=_pct(row.avg_utilization),
         rgu_unit=ncfg.rgu_unit.unit_long,
         user_unit=ncfg.user_unit.unit_long,
         top_jobs_count=len(row.top_jobs),
-        jobs_section=_jobs_section(
+        top_jobs_section=_jobs_section(
             row.top_jobs,
             rgu_value=lambda j: j.rgu_hours_used,
-            rgu_factor=ncfg.rgu_unit.factor,
+            hours_per_unit=ncfg.rgu_unit.hours_per_unit,
             suffix=ncfg.rgu_unit.unit,
+        ),
+        bottom_jobs_count=len(row.bottom_jobs),
+        bottom_jobs_section=_jobs_section(
+            row.bottom_jobs,
+            rgu_value=lambda j: j.wasted,
+            hours_per_unit=ncfg.rgu_unit.hours_per_unit,
+            suffix=f"{ncfg.rgu_unit.unit} unused",
         ),
         dashboard_url=_dashboard_url(ncfg.dashboard_url, window_start, window_end),
     ).rstrip()
@@ -225,7 +232,7 @@ def build_recurring_table(
             flags = _build_flag_cells(row)
             lines.append(
                 f"{pfx} {row.email:<{email_w}}"
-                f"  {_fmt_rgu_int(row.wasted_current_active_window, ncfg.rgu_unit.factor):>12}"
+                f"  {_fmt_rgu_int(row.wasted_current_active_window, ncfg.rgu_unit.hours_per_unit):>12}"
                 f"  {row.cluster_share * 100:>3.0f} %" + flags
             )
 
@@ -262,7 +269,7 @@ def build_admin_digest(
     ]
 
     clusters = [r.by_cluster[0].cluster if r.by_cluster else "unknown" for r in ranked]
-    wasted_s = [_fmt_rgu(r.wasted, ncfg.rgu_unit.factor) for r in ranked]
+    wasted_s = [_fmt_rgu(r.wasted, ncfg.rgu_unit.hours_per_unit) for r in ranked]
     ratio_s = [_pct(r.waste_ratio) for r in ranked]
 
     if ranked:

--- a/sarc/notifications/usage.py
+++ b/sarc/notifications/usage.py
@@ -103,8 +103,12 @@ class UsageRow:
     # their total allocation size.
     wasted: float = 0.0
     by_cluster: list[UsageClusterBreakdown] = field(default_factory=list)
-    # Top-N GPU jobs by RGU-hours unused, descending.
+    # Top-N GPU jobs by GPU utilization (SM occupancy), descending -- the
+    # user's most efficient jobs.
     top_jobs: list[UsageJob] = field(default_factory=list)
+    # Bottom-N GPU jobs by RGU-hours unused, descending, excluding any job
+    # already selected in top_jobs.
+    bottom_jobs: list[UsageJob] = field(default_factory=list)
 
     # waste_ratio = wasted / rgu_hours  (= 1 - rgu_used / rgu_hours)
     @cached_property
@@ -453,7 +457,7 @@ def get_underusers_usage(
     *,
     min_waste_ratio: float,
     min_waste_rgu_hours: float,
-    top_jobs_per_user: int = 5,
+    max_jobs_per_user: int = 5,
     clusters: list[str] | None = None,
     utilization_ceiling: float = 1.0,
     user_emails: list[str] | None = None,
@@ -472,15 +476,31 @@ def get_underusers_usage(
         start,
         end,
         usage_filter=filter_underusers,
-        fetch_jobs_per_user=top_jobs_per_user > 0,
+        fetch_jobs_per_user=max_jobs_per_user > 0,
         clusters=clusters,
         utilization_ceiling=utilization_ceiling,
         user_emails=user_emails,
     )
 
     for row in result:
-        row.top_jobs.sort(key=lambda j: j.wasted, reverse=True)  # ty:ignore[no-matching-overload]
-        row.top_jobs = row.top_jobs[:top_jobs_per_user]
+        # Least efficient jobs, by wasted resources. Computed first (unlike
+        # get_users_usage) because this is the underuser digest -- the worst
+        # jobs are the whole point of the message, so they get first pick of
+        # any job that would otherwise land in both lists.
+        all_jobs = row.top_jobs
+        row.bottom_jobs = sorted(
+            all_jobs, key=lambda j: j.wasted, reverse=True
+        )[  # ty:ignore[no-matching-overload]
+            :max_jobs_per_user
+        ]
+
+        # Most efficient jobs, by GPU utilization, excluding anything already
+        # shown in bottom_jobs.
+        top_job_ids = {j.job_id for j in row.bottom_jobs}
+        remaining_jobs = [j for j in all_jobs if j.job_id not in top_job_ids]
+        row.top_jobs = sorted(
+            remaining_jobs, key=lambda j: j.gpu_sm_occupancy, reverse=True
+        )[:max_jobs_per_user]
 
     return result
 
@@ -490,7 +510,7 @@ def get_users_usage(
     end: datetime,
     *,
     min_usage_rgu_hours: float = 0.0,
-    top_jobs_per_user: int = 5,
+    max_jobs_per_user: int = 5,
     clusters: list[str] | None = None,
     user_emails: list[str] | None = None,
 ) -> list[UsageRow]:
@@ -501,15 +521,30 @@ def get_users_usage(
         start,
         end,
         usage_filter=filter_users,
-        fetch_jobs_per_user=top_jobs_per_user > 0,
+        fetch_jobs_per_user=max_jobs_per_user > 0,
         clusters=clusters,
         user_emails=user_emails,
     )
 
-    # Sorted by GPU utilization so these are the user's *most efficient* jobs
     for row in result:
-        row.top_jobs.sort(key=lambda j: j.gpu_sm_occupancy, reverse=True)
-        row.top_jobs = row.top_jobs[:top_jobs_per_user]
+        # Most efficient jobs, by GPU utilization. Computed first (unlike
+        # get_underusers_usage) because this is the neutral usage report --
+        # it leads with the best-jobs section, so that gets first pick of any
+        # job that would otherwise land in both lists.
+        all_jobs = row.top_jobs
+        row.top_jobs = sorted(all_jobs, key=lambda j: j.gpu_sm_occupancy, reverse=True)[
+            :max_jobs_per_user
+        ]
+
+        # Least efficient jobs, by wasted resources, excluding anything already
+        # shown in top_jobs.
+        top_job_ids = {j.job_id for j in row.top_jobs}
+        remaining_jobs = [j for j in all_jobs if j.job_id not in top_job_ids]
+        row.bottom_jobs = sorted(
+            remaining_jobs, key=lambda j: j.wasted, reverse=True
+        )[  # ty:ignore[no-matching-overload]
+            :max_jobs_per_user
+        ]
 
     return result
 

--- a/tests/unittests/notifications/_factory.py
+++ b/tests/unittests/notifications/_factory.py
@@ -20,9 +20,9 @@ _REPO_ROOT = Path(__file__).parent.parent.parent.parent
 UNDERUSAGE_REPORT_TEMPLATE = """{name}
 {window_weeks} {window_range} {rgu_allocated} {rgu_unit} {avg_utilization}
 leaving {rgu_wasted} {rgu_unit} unused (or about {user_wasted} {user_unit})
-top_jobs_count:{top_jobs_count}
+bottom_jobs_count:{bottom_jobs_count}
 ```
-{jobs_section}
+{bottom_jobs_section}
 ```
 Track your usage over time: {dashboard_url}
 """
@@ -33,7 +33,11 @@ USAGE_REPORT_TEMPLATE = """{name}
 {user_allocated} {user_unit}) {avg_utilization}
 top_jobs_count:{top_jobs_count}
 ```
-{jobs_section}
+{top_jobs_section}
+```
+bottom_jobs_count:{bottom_jobs_count}
+```
+{bottom_jobs_section}
 ```
 Track your usage over time: {dashboard_url}
 """

--- a/tests/unittests/notifications/test_classify_cycle.py
+++ b/tests/unittests/notifications/test_classify_cycle.py
@@ -129,7 +129,7 @@ def test_isunderuser_matches_get_underusers_usage_membership(classify_db):
         _CYCLE_END,
         min_waste_ratio=_MIN_WASTE_RATIO,
         min_waste_rgu_hours=_MIN_WASTE_RGU_HOURS,
-        top_jobs_per_user=0,
+        max_jobs_per_user=0,
     )
     live_underusers = {r.user_id for r in live_rows}
 

--- a/tests/unittests/notifications/test_messages.py
+++ b/tests/unittests/notifications/test_messages.py
@@ -89,6 +89,23 @@ _USAGE_JOB_FIR = UsageJob(
     gpu_sm_occupancy=None,
 )
 
+_USAGE_JOB_NARVAL_3 = UsageJob(
+    job_id=300004,
+    cluster="narval",
+    submit_time=datetime(2026, 6, 2, tzinfo=UTC),
+    wasted=80.0,
+    rgu_hours_used=10.0,
+    gpu_sm_occupancy=0.05,
+)
+_USAGE_JOB_FIR_2 = UsageJob(
+    job_id=300005,
+    cluster="fir",
+    submit_time=datetime(2026, 5, 31, tzinfo=UTC),
+    wasted=40.0,
+    rgu_hours_used=5.0,
+    gpu_sm_occupancy=0.02,
+)
+
 _USAGE_ROW_ALICE = UsageRow(
     email="alice@mila.quebec",
     display_name="Alice Liddell",
@@ -100,6 +117,7 @@ _USAGE_ROW_ALICE = UsageRow(
         UsageClusterBreakdown("fir", 300.0, 220.0, 300.0 - 220.0),
     ],
     top_jobs=[_USAGE_JOB_NARVAL_1, _USAGE_JOB_NARVAL_2, _USAGE_JOB_FIR],
+    bottom_jobs=[_USAGE_JOB_NARVAL_3, _USAGE_JOB_FIR_2],
 )
 
 _USAGE_ROW_BOB = UsageRow(
@@ -144,11 +162,11 @@ def test_usage_report():
     # Test overview contains the real date range
     assert _date_range(_WINDOW_START, _WINDOW_END) in text
     # Test overview contains rgu used
-    assert _fmt_rgu(_USAGE_ROW_ALICE.rgu_hours, rgu_unit.factor) in text
+    assert _fmt_rgu(_USAGE_ROW_ALICE.rgu_hours, rgu_unit.hours_per_unit) in text
     # Test overview contains rgu long unit
     assert rgu_unit.unit_long in text
     # Test overview contains user friendly used
-    assert _fmt_rgu(_USAGE_ROW_ALICE.rgu_hours, user_unit.factor) in text
+    assert _fmt_rgu(_USAGE_ROW_ALICE.rgu_hours, user_unit.hours_per_unit) in text
     # Test overview contains user friendly long unit
     assert user_unit.unit_long in text
     # Test overview contains utilization
@@ -163,8 +181,20 @@ def test_usage_report():
         _jobs_section(
             _USAGE_ROW_ALICE.top_jobs,
             rgu_value=lambda j: j.rgu_hours_used,
-            rgu_factor=rgu_unit.factor,
+            hours_per_unit=rgu_unit.hours_per_unit,
             suffix=rgu_unit.unit,
+        )
+        in text
+    )
+    # Test overview contains bottom (least efficient) jobs count
+    assert f"bottom_jobs_count:{len(_USAGE_ROW_ALICE.bottom_jobs)}" in text
+    # Test bottom job line format
+    assert (
+        _jobs_section(
+            _USAGE_ROW_ALICE.bottom_jobs,
+            rgu_value=lambda j: j.wasted,
+            hours_per_unit=rgu_unit.hours_per_unit,
+            suffix=f"{rgu_unit.unit} unused",
         )
         in text
     )
@@ -215,6 +245,7 @@ _ROW_ALICE = UsageRow(
         UsageClusterBreakdown("fir", 300.0, 255.0, 300.0 - 255.0),
     ],
     top_jobs=[_JOB_NARVAL_1, _JOB_NARVAL_2, _JOB_FIR],
+    bottom_jobs=[_JOB_NARVAL_1, _JOB_NARVAL_2, _JOB_FIR],
 )
 
 _ROW_BOB = UsageRow(
@@ -266,28 +297,28 @@ def test_underusage_report():
     # Test overview contains the real date range
     assert _date_range(_WINDOW_START, _WINDOW_END) in text
     # Test overview contains rgu used
-    assert _fmt_rgu(_ROW_ALICE.rgu_hours, rgu_unit.factor) in text
+    assert _fmt_rgu(_ROW_ALICE.rgu_hours, rgu_unit.hours_per_unit) in text
     # Test overview contains rgu long unit
     assert rgu_unit.unit_long in text
     # Test overview contains utilization
     assert _pct(_ROW_ALICE.avg_utilization) in text
     # Test overview contains unused hours
-    assert _fmt_rgu(_ROW_ALICE.wasted, rgu_unit.factor) in text
+    assert _fmt_rgu(_ROW_ALICE.wasted, rgu_unit.hours_per_unit) in text
     # Test overview contains user friendly used
-    assert _fmt_rgu(_ROW_ALICE.wasted, user_unit.factor) in text
+    assert _fmt_rgu(_ROW_ALICE.wasted, user_unit.hours_per_unit) in text
     # Test overview contains user friendly long unit
     assert user_unit.unit_long in text
-    # Test overview contains top jobs count
-    assert f"top_jobs_count:{len(_ROW_ALICE.top_jobs)}" in text
-    # Test top jobs grouped by cluster
+    # Test overview contains bottom jobs count
+    assert f"bottom_jobs_count:{len(_ROW_ALICE.bottom_jobs)}" in text
+    # Test bottom jobs grouped by cluster
     # narval block appears before fir block (narval has more total waste)
     assert text.index("Cluster narval") < text.index("Cluster fir")
     # Test job line format
     assert (
         _jobs_section(
-            _ROW_ALICE.top_jobs,
+            _ROW_ALICE.bottom_jobs,
             rgu_value=lambda j: j.wasted,
-            rgu_factor=rgu_unit.factor,
+            hours_per_unit=rgu_unit.hours_per_unit,
             suffix=f"{rgu_unit.unit} unused",
         )
         in text
@@ -357,7 +388,7 @@ def test_digest():
         rgu_unit = config.sarc.notifications.rgu_unit
         text = build_admin_digest([_ROW_BOB], period="…", **_DIGEST_KW)
     # Test contains unused hours
-    assert f"{_fmt_rgu(600.0, rgu_unit.factor)} {rgu_unit.unit} unused" in text
+    assert f"{_fmt_rgu(600.0, rgu_unit.hours_per_unit)} {rgu_unit.unit} unused" in text
     # Test contains waste ratio
     assert "75.0 %" in text
 

--- a/tests/unittests/notifications/test_recurring.py
+++ b/tests/unittests/notifications/test_recurring.py
@@ -436,7 +436,7 @@ def test_table_wasted_formatted_with_space_thousands():
     with gifnoc.overlay({"sarc.notifications": _NOTIFY_CFG}) as config:
         rgu_unit = config.sarc.notifications.rgu_unit
         text = build_recurring_table({"narval": [_ROW_ALICE]}, **_BRT_KW)
-    assert _fmt_rgu_int(4200, rgu_unit.factor) in text
+    assert _fmt_rgu_int(4200, rgu_unit.hours_per_unit) in text
 
 
 def test_table_share_percentage():

--- a/tests/unittests/notifications/test_usage.py
+++ b/tests/unittests/notifications/test_usage.py
@@ -28,7 +28,7 @@ _WINDOW_START = datetime(2024, 6, 1, tzinfo=UTC)
 _WINDOW_END = datetime(2024, 6, 30, tzinfo=UTC)
 _MIN_WASTE_RATIO = 0.50
 _MIN_WASTE_RGU_HOURS = 672.0  # RGU-hours floor
-_TOP_JOBS_PER_USER = 5
+_MAX_JOBS_PER_USER = 5
 
 # mila: billing_is_gpu=True, gpu_type A100-SXM4-80GB → rgu = 4.8
 _MILA_GPU_TYPE = "A100-SXM4-80GB"
@@ -157,7 +157,7 @@ def test_underusers_filtering_and_top_jobs(underusage_db):
         _WINDOW_END,
         min_waste_ratio=_MIN_WASTE_RATIO,
         min_waste_rgu_hours=_MIN_WASTE_RGU_HOURS,
-        top_jobs_per_user=_TOP_JOBS_PER_USER,
+        max_jobs_per_user=_MAX_JOBS_PER_USER,
     )
     # Test high waster is returned
     assert "petitbonhomme@mila.quebec" in {r.email for r in results}
@@ -172,15 +172,15 @@ def test_underusers_filtering_and_top_jobs(underusage_db):
     # mila:   4.8 * 700 * 0.9 + extras ≈ 4152 RGU-h wasted
     assert row.by_cluster[0].cluster == "raisin"
 
-    # Test top jobs capped at five
-    assert len(row.top_jobs) == _TOP_JOBS_PER_USER
+    # Test bottom jobs capped at five
+    assert len(row.bottom_jobs) == _MAX_JOBS_PER_USER
 
-    # Test top jobs ordered desc by rgu hours unused
-    unused = [j.wasted for j in row.top_jobs]
+    # Test bottom jobs ordered desc by rgu hours unused
+    unused = [j.wasted for j in row.bottom_jobs]
     assert unused == sorted(unused, reverse=True)
 
-    # Test top jobs have utilization
-    assert all(j.gpu_sm_occupancy is not None for j in row.top_jobs)
+    # Test bottom jobs have utilization
+    assert all(j.gpu_sm_occupancy is not None for j in row.bottom_jobs)
 
 
 # ── Overview fields ───────────────────────────────────────────────────────────
@@ -192,7 +192,7 @@ def test_underusers_overview_fields(underusage_db):
         _WINDOW_END,
         min_waste_ratio=0.0,
         min_waste_rgu_hours=0.0,
-        top_jobs_per_user=_TOP_JOBS_PER_USER,
+        max_jobs_per_user=_MAX_JOBS_PER_USER,
     )
     row = next(r for r in results if r.email == "beaubonhomme@mila.quebec")
     # rgu_used / rgu_requested = 0.80
@@ -216,7 +216,7 @@ def test_outside_window_excluded(underusage_db):
             after,
             min_waste_ratio=0.0,
             min_waste_rgu_hours=0.0,
-            top_jobs_per_user=_TOP_JOBS_PER_USER,
+            max_jobs_per_user=_MAX_JOBS_PER_USER,
         )
         == []
     )
@@ -255,7 +255,7 @@ def test_run_concurrently_empty_tasks_returns_empty_list():
 def test_usage_all_users_overview_and_top_jobs(underusage_db):
     # All 3 users have GPU jobs in the window — no threshold filtering.
     results = get_users_usage(
-        _WINDOW_START, _WINDOW_END, top_jobs_per_user=_TOP_JOBS_PER_USER
+        _WINDOW_START, _WINDOW_END, max_jobs_per_user=_MAX_JOBS_PER_USER
     )
     emails = {r.email for r in results}
     assert "petitbonhomme@mila.quebec" in emails
@@ -272,40 +272,58 @@ def test_usage_all_users_overview_and_top_jobs(underusage_db):
 
     row = next(r for r in results if r.email == "petitbonhomme@mila.quebec")
     # petitbonhomme has 8 mila jobs + 1 raisin job = 9 total, capped at 5.
-    assert len(row.top_jobs) == _TOP_JOBS_PER_USER
+    assert len(row.top_jobs) == _MAX_JOBS_PER_USER
 
     # Test top jobs ordered desc by GPU utilization (most efficient first)
     occ = [j.gpu_sm_occupancy for j in row.top_jobs]
     assert occ == sorted(occ, reverse=True)
 
+    # Test bottom jobs (least efficient, by wasted resources): only 3 jobs
+    # remain after the top 5 are taken from 8 total, so the cap is not hit.
+    assert len(row.bottom_jobs) == 3
+    wasted = [j.wasted for j in row.bottom_jobs]
+    assert wasted == sorted(wasted, reverse=True)
+
+    # Test no job appears in both lists
+    top_ids = {j.job_id for j in row.top_jobs}
+    bottom_ids = {j.job_id for j in row.bottom_jobs}
+    assert top_ids.isdisjoint(bottom_ids)
+
 
 def test_usage_outside_window_excluded(underusage_db):
     before = datetime(2020, 1, 1, tzinfo=UTC)
     after = datetime(2020, 12, 31, tzinfo=UTC)
-    assert get_users_usage(before, after, top_jobs_per_user=_TOP_JOBS_PER_USER) == []
+    assert get_users_usage(before, after, max_jobs_per_user=_MAX_JOBS_PER_USER) == []
 
 
-# ── top_jobs_per_user is config-driven ───────────────────────────────────────
+# ── max_jobs_per_user is config-driven ───────────────────────────────────────
 
 
-def test_top_jobs_per_user_3(underusage_db):
+def test_max_jobs_per_user_3(underusage_db):
     # petitbonhomme has >5 jobs; verify the cap follows the param.
     results = get_underusers_usage(
         _WINDOW_START,
         _WINDOW_END,
         min_waste_ratio=_MIN_WASTE_RATIO,
         min_waste_rgu_hours=_MIN_WASTE_RGU_HOURS,
-        top_jobs_per_user=3,
+        max_jobs_per_user=3,
     )
     row = next(r for r in results if r.email == "petitbonhomme@mila.quebec")
-    assert len(row.top_jobs) == 3
+    assert len(row.bottom_jobs) == 3
 
 
-def test_usage_top_jobs_per_user_3(underusage_db):
+def test_usage_max_jobs_per_user_3(underusage_db):
     # petitbonhomme has 9 jobs total; verify the cap follows the param.
-    results = get_users_usage(_WINDOW_START, _WINDOW_END, top_jobs_per_user=3)
+    results = get_users_usage(_WINDOW_START, _WINDOW_END, max_jobs_per_user=3)
     row = next(r for r in results if r.email == "petitbonhomme@mila.quebec")
     assert len(row.top_jobs) == 3
+
+    # bottom_jobs uses the same knob: 8 total jobs, top 3 taken, 5 remain — the
+    # cap (3) is hit here, unlike the max_jobs_per_user=5 case above.
+    assert len(row.bottom_jobs) == 3
+    top_ids = {j.job_id for j in row.top_jobs}
+    bottom_ids = {j.job_id for j in row.bottom_jobs}
+    assert top_ids.isdisjoint(bottom_ids)
 
 
 # ── Cluster filter ────────────────────────────────────────────────────────────
@@ -318,7 +336,7 @@ def test_clusters_filter_excludes_other_clusters(underusage_db):
         _WINDOW_END,
         min_waste_ratio=_MIN_WASTE_RATIO,
         min_waste_rgu_hours=_MIN_WASTE_RGU_HOURS,
-        top_jobs_per_user=_TOP_JOBS_PER_USER,
+        max_jobs_per_user=_MAX_JOBS_PER_USER,
         clusters=["mila"],
     )
     petitbonhomme = next(r for r in results if "petitbonhomme" in r.email)
@@ -334,7 +352,7 @@ def test_get_underusers_user_emails_filters_to_single_user(underusage_db):
         _WINDOW_END,
         min_waste_ratio=0.0,
         min_waste_rgu_hours=0.0,
-        top_jobs_per_user=_TOP_JOBS_PER_USER,
+        max_jobs_per_user=_MAX_JOBS_PER_USER,
         user_emails=["petitbonhomme@mila.quebec"],
     )
     # At threshold 0.0, beaubonhomme and bramin would normally also qualify —
@@ -346,7 +364,7 @@ def test_get_underusers_user_emails_none_matches_default(underusage_db):
     kwargs = dict(
         min_waste_ratio=0.0,
         min_waste_rgu_hours=0.0,
-        top_jobs_per_user=_TOP_JOBS_PER_USER,
+        max_jobs_per_user=_MAX_JOBS_PER_USER,
     )
     with_none = get_underusers_usage(
         _WINDOW_START, _WINDOW_END, user_emails=None, **kwargs
@@ -362,7 +380,7 @@ def test_get_underusers_user_emails_empty_list_returns_no_rows(underusage_db):
         _WINDOW_END,
         min_waste_ratio=0.0,
         min_waste_rgu_hours=0.0,
-        top_jobs_per_user=_TOP_JOBS_PER_USER,
+        max_jobs_per_user=_MAX_JOBS_PER_USER,
         user_emails=[],
     )
     assert results == []
@@ -372,7 +390,7 @@ def test_get_all_users_usage_user_emails_filters_to_single_user(underusage_db):
     results = get_users_usage(
         _WINDOW_START,
         _WINDOW_END,
-        top_jobs_per_user=_TOP_JOBS_PER_USER,
+        max_jobs_per_user=_MAX_JOBS_PER_USER,
         user_emails=["beaubonhomme@mila.quebec"],
     )
     assert {r.email for r in results} == {"beaubonhomme@mila.quebec"}
@@ -382,7 +400,7 @@ def test_get_all_users_usage_user_emails_none_returns_all(underusage_db):
     results = get_users_usage(
         _WINDOW_START,
         _WINDOW_END,
-        top_jobs_per_user=_TOP_JOBS_PER_USER,
+        max_jobs_per_user=_MAX_JOBS_PER_USER,
         user_emails=None,
     )
     emails = {r.email for r in results}
@@ -400,7 +418,7 @@ def test_get_all_users_usage_exclusion_only_list_does_not_match_nobody(underusag
     results = get_users_usage(
         _WINDOW_START,
         _WINDOW_END,
-        top_jobs_per_user=_TOP_JOBS_PER_USER,
+        max_jobs_per_user=_MAX_JOBS_PER_USER,
         user_emails=["~petitbonhomme@mila.quebec"],
     )
     emails = {r.email for r in results}
@@ -417,7 +435,7 @@ def test_true_wasted_field_at_identity(underusage_db):
         _WINDOW_END,
         min_waste_ratio=0.0,
         min_waste_rgu_hours=0.0,
-        top_jobs_per_user=_TOP_JOBS_PER_USER,
+        max_jobs_per_user=_MAX_JOBS_PER_USER,
         utilization_ceiling=1.0,
     )
     for row in results:
@@ -437,7 +455,7 @@ def test_scaled_waste_less_than_true_waste_below_threshold(underusage_db):
         _WINDOW_END,
         min_waste_ratio=_MIN_WASTE_RATIO,
         min_waste_rgu_hours=_MIN_WASTE_RGU_HOURS,
-        top_jobs_per_user=_TOP_JOBS_PER_USER,
+        max_jobs_per_user=_MAX_JOBS_PER_USER,
         utilization_ceiling=0.80,
     )
     row = next(r for r in results if "petitbonhomme" in r.email)
@@ -454,7 +472,7 @@ def test_subtractive_formula_exact_waste_ratio(underusage_db):
         _WINDOW_END,
         min_waste_ratio=_MIN_WASTE_RATIO,
         min_waste_rgu_hours=_MIN_WASTE_RGU_HOURS,
-        top_jobs_per_user=_TOP_JOBS_PER_USER,
+        max_jobs_per_user=_MAX_JOBS_PER_USER,
         utilization_ceiling=0.80,
     )
     row = next(r for r in results if "petitbonhomme" in r.email)
@@ -467,7 +485,7 @@ def test_subtractive_formula_exact_waste_ratio(underusage_db):
         _WINDOW_END,
         min_waste_ratio=0.10,
         min_waste_rgu_hours=_MIN_WASTE_RGU_HOURS,
-        top_jobs_per_user=_TOP_JOBS_PER_USER,
+        max_jobs_per_user=_MAX_JOBS_PER_USER,
         utilization_ceiling=0.20,
     )
     row = next(r for r in results if "petitbonhomme" in r.email)
@@ -483,7 +501,7 @@ def test_subtractive_formula_boundary_zero_waste(underusage_db):
         _WINDOW_END,
         min_waste_ratio=0.0,
         min_waste_rgu_hours=0.0,
-        top_jobs_per_user=_TOP_JOBS_PER_USER,
+        max_jobs_per_user=_MAX_JOBS_PER_USER,
         utilization_ceiling=0.80,
     )
     row = next(r for r in results if "beaubonhomme" in r.email)
@@ -495,7 +513,7 @@ def test_subtractive_formula_boundary_zero_waste(underusage_db):
         _WINDOW_END,
         min_waste_ratio=0.05,
         min_waste_rgu_hours=0.0,
-        top_jobs_per_user=_TOP_JOBS_PER_USER,
+        max_jobs_per_user=_MAX_JOBS_PER_USER,
         utilization_ceiling=0.90,
     )
     row = next(r for r in results if "beaubonhomme" in r.email)
@@ -511,12 +529,12 @@ def test_top_job_gpu_sm_occupancy_is_raw_mean(underusage_db):
         _WINDOW_END,
         min_waste_ratio=_MIN_WASTE_RATIO,
         min_waste_rgu_hours=_MIN_WASTE_RGU_HOURS,
-        top_jobs_per_user=_TOP_JOBS_PER_USER,
+        max_jobs_per_user=_MAX_JOBS_PER_USER,
         utilization_ceiling=0.80,
     )
     row = next(r for r in results if "petitbonhomme" in r.email)
-    raisin_job = next(j for j in row.top_jobs if j.cluster == "raisin")
-    mila_top = next(j for j in row.top_jobs if j.cluster == "mila")
+    raisin_job = next(j for j in row.bottom_jobs if j.cluster == "raisin")
+    mila_top = next(j for j in row.bottom_jobs if j.cluster == "mila")
     assert raisin_job.gpu_sm_occupancy == pytest.approx(0.0, abs=1e-6)
     assert mila_top.gpu_sm_occupancy == pytest.approx(0.10, abs=1e-6)
 
@@ -529,7 +547,7 @@ def test_usage_floor_excludes_below_threshold(underusage_db):
     results = get_users_usage(
         _WINDOW_START,
         _WINDOW_END,
-        top_jobs_per_user=_TOP_JOBS_PER_USER,
+        max_jobs_per_user=_MAX_JOBS_PER_USER,
         min_usage_rgu_hours=500.0,
     )
     emails = {r.email for r in results}
@@ -542,7 +560,7 @@ def test_usage_floor_at_boundary_is_excluded(underusage_db):
     results = get_users_usage(
         _WINDOW_START,
         _WINDOW_END,
-        top_jobs_per_user=_TOP_JOBS_PER_USER,
+        max_jobs_per_user=_MAX_JOBS_PER_USER,
         min_usage_rgu_hours=481.0,
     )
     emails = {r.email for r in results}
@@ -580,7 +598,7 @@ def test_missing_util_not_flagged(missing_util_db):
         _WINDOW_END,
         min_waste_ratio=_MIN_WASTE_RATIO,
         min_waste_rgu_hours=_MIN_WASTE_RGU_HOURS,
-        top_jobs_per_user=_TOP_JOBS_PER_USER,
+        max_jobs_per_user=_MAX_JOBS_PER_USER,
     )
     assert "bramin@mila.quebec" not in {r.email for r in results}
 
@@ -594,7 +612,7 @@ def test_missing_util_zero_waste(missing_util_db):
         _WINDOW_END,
         min_waste_ratio=0.0,
         min_waste_rgu_hours=0.0,
-        top_jobs_per_user=_TOP_JOBS_PER_USER,
+        max_jobs_per_user=_MAX_JOBS_PER_USER,
     )
     assert "bramin@mila.quebec" not in {r.email for r in results}
 
@@ -608,7 +626,7 @@ def test_missing_util_non_negative_waste_at_sub_threshold(missing_util_db):
         _WINDOW_END,
         min_waste_ratio=0.0,
         min_waste_rgu_hours=0.0,
-        top_jobs_per_user=_TOP_JOBS_PER_USER,
+        max_jobs_per_user=_MAX_JOBS_PER_USER,
         utilization_ceiling=0.8,
     )
     assert "bramin@mila.quebec" not in {r.email for r in results}
@@ -619,7 +637,7 @@ def test_missing_util_usage_rgu_hours_used_equals_requested(missing_util_db):
     # gpu_sm_occupancy stat), so he never produces a user_data entry and
     # never reaches get_all_users_usage's usage-floor check at all.
     results = get_users_usage(
-        _WINDOW_START, _WINDOW_END, top_jobs_per_user=_TOP_JOBS_PER_USER
+        _WINDOW_START, _WINDOW_END, max_jobs_per_user=_MAX_JOBS_PER_USER
     )
     assert "bramin@mila.quebec" not in {r.email for r in results}
 
@@ -659,6 +677,6 @@ def test_zero_cost_job_does_not_crash(zero_cost_db):
         _WINDOW_END,
         min_waste_ratio=_MIN_WASTE_RATIO,
         min_waste_rgu_hours=_MIN_WASTE_RGU_HOURS,
-        top_jobs_per_user=_TOP_JOBS_PER_USER,
+        max_jobs_per_user=_MAX_JOBS_PER_USER,
     )
     assert "bramin@mila.quebec" not in {r.email for r in results}


### PR DESCRIPTION
## Summary
`top_jobs` used to mean different things depending on which function populated it — most-wasteful in the underuser digest, most-efficient in the general usage report — so its doc comment read as false in the second case. This unifies the semantics and cleans up the docs/config that had gone stale around it.

## Changes
- `sarc/notifications/usage.py`: `top_jobs` now always means the user's most efficient jobs (by GPU SM occupancy) and `bottom_jobs` always means the most wasted jobs, consistently in both `get_underusers_usage` and `get_users_usage`; added comments explaining why each function resolves the top/bottom split in the opposite priority order.
- Renamed `top_jobs_per_user` → `max_jobs_per_user` across `sarc/config.py`, `config/sarc-ref.yaml`, `sarc/cli/notify/usage.py`, and callers/tests, since the knob caps both the best- and worst-jobs lists, not just "top".
- Renamed `UsageNotifyUnitConfig.factor` → `hours_per_unit` (and flipped the division direction accordingly) in `sarc/config.py` / `sarc/notifications/messages.py` for a clearer config semantic.
- Fixed stale comments/docstrings that still described the old, inconsistent `top_jobs`/`bottom_jobs` behavior (`sarc/notifications/usage.py`, `sarc/config.py`, `config/sarc-ref.yaml`), and renamed a misleading `top_jobs` parameter in `messages.py::_jobs_section` (used for both lists) to `jobs`.
- Added `rgu_unit`/`user_unit` display-unit entries to `config/sarc-ref.yaml`.
- Updated `tests/unittests/notifications/` to cover the new split and renames.

## Notes
Config-facing rename (`top_jobs_per_user` → `max_jobs_per_user`) — any external config referencing the old key name needs updating.